### PR TITLE
Add Plex integration and library region metadata.

### DIFF
--- a/src/Tindarr.Api/Controllers/PlexController.cs
+++ b/src/Tindarr.Api/Controllers/PlexController.cs
@@ -1,0 +1,205 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Tindarr.Api.Auth;
+using Tindarr.Application.Interfaces.Integrations;
+using Tindarr.Application.Interfaces.Preferences;
+using Tindarr.Contracts.Plex;
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/v1/plex")]
+public sealed class PlexController(
+	IPlexService plexService,
+	IUserPreferencesService preferencesService) : ControllerBase
+{
+	[Authorize(Policy = Policies.AdminOnly)]
+	[HttpGet("auth/status")]
+	public async Task<ActionResult<PlexAuthStatusResponse>> GetAuthStatus(CancellationToken cancellationToken)
+	{
+		var status = await plexService.GetAuthStatusAsync(cancellationToken);
+		return Ok(new PlexAuthStatusResponse(status.HasClientIdentifier, status.HasAuthToken));
+	}
+
+	[Authorize(Policy = Policies.AdminOnly)]
+	[HttpPost("pin")]
+	public async Task<ActionResult<PlexPinCreateResponse>> CreatePin(CancellationToken cancellationToken)
+	{
+		try
+		{
+			var pin = await plexService.CreatePinAsync(cancellationToken);
+			return Ok(new PlexPinCreateResponse(pin.PinId, pin.Code, pin.ExpiresAtUtc, pin.AuthUrl));
+		}
+		catch (HttpRequestException)
+		{
+			return StatusCode(StatusCodes.Status503ServiceUnavailable, "Plex request failed.");
+		}
+		catch (TaskCanceledException)
+		{
+			return StatusCode(StatusCodes.Status504GatewayTimeout, "Plex request timed out.");
+		}
+	}
+
+	[Authorize(Policy = Policies.AdminOnly)]
+	[HttpPost("pins/{pinId:long}/verify")]
+	public async Task<ActionResult<PlexPinStatusResponse>> VerifyPin(
+		[FromRoute] long pinId,
+		CancellationToken cancellationToken)
+	{
+		try
+		{
+			var status = await plexService.VerifyPinAsync(pinId, cancellationToken);
+			return Ok(new PlexPinStatusResponse(status.PinId, status.Code, status.ExpiresAtUtc, status.Authorized));
+		}
+		catch (HttpRequestException)
+		{
+			return StatusCode(StatusCodes.Status503ServiceUnavailable, "Plex request failed.");
+		}
+		catch (TaskCanceledException)
+		{
+			return StatusCode(StatusCodes.Status504GatewayTimeout, "Plex request timed out.");
+		}
+	}
+
+	[Authorize(Policy = Policies.AdminOnly)]
+	[HttpGet("servers")]
+	public async Task<ActionResult<IReadOnlyList<PlexServerDto>>> ListServers(CancellationToken cancellationToken)
+	{
+		var servers = await plexService.ListServersAsync(cancellationToken);
+		return Ok(servers.Select(MapServer).ToList());
+	}
+
+	[Authorize(Policy = Policies.AdminOnly)]
+	[HttpPost("servers/sync")]
+	public async Task<ActionResult<IReadOnlyList<PlexServerDto>>> SyncServers(CancellationToken cancellationToken)
+	{
+		try
+		{
+			var servers = await plexService.RefreshServersAsync(cancellationToken);
+			return Ok(servers.Select(MapServer).ToList());
+		}
+		catch (InvalidOperationException ex)
+		{
+			return StatusCode(StatusCodes.Status503ServiceUnavailable, ex.Message);
+		}
+		catch (HttpRequestException)
+		{
+			return StatusCode(StatusCodes.Status503ServiceUnavailable, "Plex request failed.");
+		}
+		catch (TaskCanceledException)
+		{
+			return StatusCode(StatusCodes.Status504GatewayTimeout, "Plex request timed out.");
+		}
+	}
+
+	[Authorize(Policy = Policies.AdminOnly)]
+	[HttpPost("library/sync")]
+	public async Task<ActionResult<PlexLibrarySyncResponse>> SyncLibrary(
+		[FromQuery] string serviceType,
+		[FromQuery] string serverId,
+		CancellationToken cancellationToken)
+	{
+		if (!TryGetScope(serviceType, serverId, out var scope, out var errorResult))
+		{
+			return errorResult!;
+		}
+
+		try
+		{
+			var result = await plexService.SyncLibraryAsync(scope!, cancellationToken);
+			return Ok(new PlexLibrarySyncResponse(
+				scope!.ServiceType.ToString().ToLowerInvariant(),
+				scope.ServerId,
+				result.Count,
+				result.SyncedAtUtc));
+		}
+		catch (InvalidOperationException ex)
+		{
+			return StatusCode(StatusCodes.Status503ServiceUnavailable, ex.Message);
+		}
+		catch (HttpRequestException)
+		{
+			return StatusCode(StatusCodes.Status503ServiceUnavailable, "Plex request failed.");
+		}
+		catch (TaskCanceledException)
+		{
+			return StatusCode(StatusCodes.Status504GatewayTimeout, "Plex request timed out.");
+		}
+	}
+
+	[HttpGet("library")]
+	public async Task<ActionResult<PlexLibraryResponse>> GetLibrary(
+		[FromQuery] string serviceType,
+		[FromQuery] string serverId,
+		[FromQuery] int limit = 50,
+		CancellationToken cancellationToken = default)
+	{
+		if (!TryGetScope(serviceType, serverId, out var scope, out var errorResult))
+		{
+			return errorResult!;
+		}
+
+		try
+		{
+			var userId = User.GetUserId();
+			var preferences = await preferencesService.GetOrDefaultAsync(userId, cancellationToken);
+			var items = await plexService.GetLibraryAsync(scope!, preferences, limit, cancellationToken);
+
+			return Ok(new PlexLibraryResponse(
+				scope!.ServiceType.ToString().ToLowerInvariant(),
+				scope.ServerId,
+				items.Count,
+				items));
+		}
+		catch (InvalidOperationException ex)
+		{
+			return StatusCode(StatusCodes.Status503ServiceUnavailable, ex.Message);
+		}
+		catch (HttpRequestException)
+		{
+			return StatusCode(StatusCodes.Status503ServiceUnavailable, "Plex request failed.");
+		}
+		catch (TaskCanceledException)
+		{
+			return StatusCode(StatusCodes.Status504GatewayTimeout, "Plex request timed out.");
+		}
+	}
+
+	private static bool TryGetScope(
+		string serviceType,
+		string serverId,
+		out ServiceScope? scope,
+		out ActionResult? errorResult)
+	{
+		errorResult = null;
+		if (!ServiceScope.TryCreate(serviceType, serverId, out scope))
+		{
+			errorResult = new BadRequestObjectResult("ServiceType and ServerId are required.");
+			return false;
+		}
+
+		if (scope!.ServiceType != ServiceType.Plex)
+		{
+			errorResult = new BadRequestObjectResult("ServiceType must be plex.");
+			return false;
+		}
+
+		return true;
+	}
+
+	private static PlexServerDto MapServer(PlexServerRecord record)
+	{
+		return new PlexServerDto(
+			record.ServerId,
+			record.Name,
+			record.BaseUrl,
+			record.Version,
+			record.Platform,
+			record.Owned,
+			record.Online,
+			record.LastLibrarySyncUtc,
+			record.UpdatedAtUtc);
+	}
+}

--- a/src/Tindarr.Api/Program.cs
+++ b/src/Tindarr.Api/Program.cs
@@ -13,6 +13,7 @@ using Tindarr.Application.Abstractions.Integrations;
 using Tindarr.Application.Abstractions.Persistence;
 using Tindarr.Application.Abstractions.Security;
 using Tindarr.Application.Features.Radarr;
+using Tindarr.Application.Features.Plex;
 using Tindarr.Application.Features.AcceptedMovies;
 using Tindarr.Application.Features.Interactions;
 using Tindarr.Application.Interfaces.Interactions;
@@ -25,6 +26,7 @@ using Tindarr.Application.Options;
 using Tindarr.Application.Services;
 using Tindarr.Infrastructure.Caching;
 using Tindarr.Infrastructure.Integrations.Radarr;
+using Tindarr.Infrastructure.Integrations.Plex;
 using Tindarr.Infrastructure.Integrations.Tmdb;
 using Tindarr.Infrastructure.Integrations.Tmdb.Http;
 using Tindarr.Infrastructure.Interactions;
@@ -125,6 +127,11 @@ builder.Services.AddOptions<RadarrOptions>()
 	.Validate(o => o.IsValid(), "Invalid Radarr configuration.")
 	.ValidateOnStart();
 
+builder.Services.AddOptions<PlexOptions>()
+	.BindConfiguration(PlexOptions.SectionName)
+	.Validate(o => o.IsValid(), "Invalid Plex configuration.")
+	.ValidateOnStart();
+
 builder.Services.AddOptions<WindowsServiceOptions>()
 	.BindConfiguration(WindowsServiceOptions.SectionName);
 
@@ -151,6 +158,7 @@ builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IUserPreferencesService, UserPreferencesService>();
 builder.Services.AddScoped<IAcceptedMoviesService, AcceptedMoviesService>();
 builder.Services.AddScoped<IRadarrService, RadarrService>();
+builder.Services.AddScoped<IPlexService, PlexService>();
 
 builder.Services.AddSingleton<IConfigureOptions<JwtBearerOptions>, ConfigureJwtBearerOptions>();
 
@@ -233,6 +241,8 @@ builder.Services.AddHttpClient<ITmdbClient, TmdbClient>((sp, client) =>
 .AddHttpMessageHandler(() => new TmdbRetryHandler(maxRetries: 3));
 
 builder.Services.AddHttpClient<IRadarrClient, RadarrClient>();
+builder.Services.AddHttpClient<IPlexAuthClient, PlexAuthClient>();
+builder.Services.AddHttpClient<IPlexLibraryClient, PlexLibraryClient>();
 
 builder.Services.AddScoped<ISwipeDeckSource, TmdbSwipeDeckSource>();
 builder.Services.AddScoped<IInteractionService, InteractionService>();

--- a/src/Tindarr.Application/Abstractions/Integrations/IPlexAuthClient.cs
+++ b/src/Tindarr.Application/Abstractions/Integrations/IPlexAuthClient.cs
@@ -1,0 +1,36 @@
+namespace Tindarr.Application.Abstractions.Integrations;
+
+public interface IPlexAuthClient
+{
+	Task<PlexPinResult> CreatePinAsync(string clientIdentifier, CancellationToken cancellationToken);
+
+	Task<PlexPinResult?> GetPinAsync(string clientIdentifier, long pinId, CancellationToken cancellationToken);
+
+	Task<PlexTokenValidationResult> ValidateTokenAsync(string clientIdentifier, string authToken, CancellationToken cancellationToken);
+
+	Task<IReadOnlyList<PlexServerResource>> GetServersAsync(string clientIdentifier, string authToken, CancellationToken cancellationToken);
+}
+
+public sealed record PlexPinResult(
+	long Id,
+	string Code,
+	DateTimeOffset? ExpiresAtUtc,
+	string? AuthToken);
+
+public sealed record PlexTokenValidationResult(bool Ok, string? Message);
+
+public sealed record PlexServerResource(
+	string MachineIdentifier,
+	string Name,
+	string? Version,
+	string? Platform,
+	bool Owned,
+	bool Online,
+	string? AccessToken,
+	IReadOnlyList<PlexServerConnection> Connections);
+
+public sealed record PlexServerConnection(
+	string Uri,
+	bool Local,
+	bool Relay,
+	string Protocol);

--- a/src/Tindarr.Application/Abstractions/Integrations/IPlexLibraryClient.cs
+++ b/src/Tindarr.Application/Abstractions/Integrations/IPlexLibraryClient.cs
@@ -1,0 +1,24 @@
+namespace Tindarr.Application.Abstractions.Integrations;
+
+public interface IPlexLibraryClient
+{
+	Task<IReadOnlyList<PlexLibrarySection>> GetMovieSectionsAsync(PlexServerConnectionInfo connection, CancellationToken cancellationToken);
+
+	Task<IReadOnlyList<PlexLibraryItem>> GetLibraryItemsAsync(PlexServerConnectionInfo connection, int sectionKey, CancellationToken cancellationToken);
+}
+
+public sealed record PlexServerConnectionInfo(
+	string BaseUrl,
+	string AccessToken,
+	string ClientIdentifier);
+
+public sealed record PlexLibrarySection(
+	int Key,
+	string Title,
+	string Type);
+
+public sealed record PlexLibraryItem(
+	int TmdbId,
+	string Title,
+	string? RatingKey,
+	string? Guid);

--- a/src/Tindarr.Application/Abstractions/Integrations/PlexConstants.cs
+++ b/src/Tindarr.Application/Abstractions/Integrations/PlexConstants.cs
@@ -1,0 +1,6 @@
+namespace Tindarr.Application.Abstractions.Integrations;
+
+public static class PlexConstants
+{
+	public const string AccountServerId = "plex-account";
+}

--- a/src/Tindarr.Application/Abstractions/Persistence/IServiceSettingsRepository.cs
+++ b/src/Tindarr.Application/Abstractions/Persistence/IServiceSettingsRepository.cs
@@ -23,6 +23,16 @@ public sealed record ServiceSettingsRecord(
 	bool RadarrAutoAddEnabled,
 	long? RadarrLastAutoAddAcceptedId,
 	DateTimeOffset? RadarrLastLibrarySyncUtc,
+	string? PlexClientIdentifier,
+	string? PlexAuthToken,
+	string? PlexServerName,
+	string? PlexServerUri,
+	string? PlexServerVersion,
+	string? PlexServerPlatform,
+	bool? PlexServerOwned,
+	bool? PlexServerOnline,
+	string? PlexServerAccessToken,
+	DateTimeOffset? PlexLastLibrarySyncUtc,
 	DateTimeOffset UpdatedAtUtc);
 
 public sealed record ServiceSettingsUpsert(
@@ -34,4 +44,14 @@ public sealed record ServiceSettingsUpsert(
 	int? RadarrTagId,
 	bool RadarrAutoAddEnabled,
 	long? RadarrLastAutoAddAcceptedId,
-	DateTimeOffset? RadarrLastLibrarySyncUtc);
+	DateTimeOffset? RadarrLastLibrarySyncUtc,
+	string? PlexClientIdentifier,
+	string? PlexAuthToken,
+	string? PlexServerName,
+	string? PlexServerUri,
+	string? PlexServerVersion,
+	string? PlexServerPlatform,
+	bool? PlexServerOwned,
+	bool? PlexServerOnline,
+	string? PlexServerAccessToken,
+	DateTimeOffset? PlexLastLibrarySyncUtc);

--- a/src/Tindarr.Application/Features/Plex/PlexService.cs
+++ b/src/Tindarr.Application/Features/Plex/PlexService.cs
@@ -1,0 +1,533 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Tindarr.Application.Abstractions.Integrations;
+using Tindarr.Application.Abstractions.Persistence;
+using Tindarr.Application.Interfaces.Integrations;
+using Tindarr.Application.Options;
+using Tindarr.Contracts.Movies;
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Application.Features.Plex;
+
+public sealed class PlexService(
+	IPlexAuthClient authClient,
+	IPlexLibraryClient libraryClient,
+	IServiceSettingsRepository settingsRepo,
+	ILibraryCacheRepository libraryCache,
+	ITmdbClient tmdbClient,
+	IOptions<PlexOptions> options,
+	ILogger<PlexService> logger) : IPlexService
+{
+	private static readonly IReadOnlyDictionary<int, string> TmdbGenreMap = new Dictionary<int, string>
+	{
+		[28] = "Action",
+		[12] = "Adventure",
+		[16] = "Animation",
+		[35] = "Comedy",
+		[80] = "Crime",
+		[99] = "Documentary",
+		[18] = "Drama",
+		[10751] = "Family",
+		[14] = "Fantasy",
+		[36] = "History",
+		[27] = "Horror",
+		[10402] = "Music",
+		[9648] = "Mystery",
+		[10749] = "Romance",
+		[878] = "Science Fiction",
+		[10770] = "TV Movie",
+		[53] = "Thriller",
+		[10752] = "War",
+		[37] = "Western"
+	};
+
+	private readonly PlexOptions _options = options.Value;
+
+	public async Task<PlexPinCreateResult> CreatePinAsync(CancellationToken cancellationToken)
+	{
+		var account = await EnsureAccountAsync(cancellationToken);
+		var pin = await authClient.CreatePinAsync(account.PlexClientIdentifier!, cancellationToken);
+		var authUrl = BuildAuthUrl(account.PlexClientIdentifier!, pin.Code);
+
+		return new PlexPinCreateResult(pin.Id, pin.Code, pin.ExpiresAtUtc, authUrl);
+	}
+
+	public async Task<PlexPinStatusResult> VerifyPinAsync(long pinId, CancellationToken cancellationToken)
+	{
+		var account = await EnsureAccountAsync(cancellationToken);
+		var pin = await authClient.GetPinAsync(account.PlexClientIdentifier!, pinId, cancellationToken);
+		if (pin is null)
+		{
+			return new PlexPinStatusResult(pinId, string.Empty, null, false);
+		}
+
+		var authorized = !string.IsNullOrWhiteSpace(pin.AuthToken);
+		if (authorized)
+		{
+			var validation = await authClient.ValidateTokenAsync(account.PlexClientIdentifier!, pin.AuthToken!, cancellationToken);
+			if (!validation.Ok)
+			{
+				authorized = false;
+			}
+			else
+			{
+				await UpdateAccountAsync(account, plexAuthToken: pin.AuthToken, cancellationToken: cancellationToken);
+			}
+		}
+
+		return new PlexPinStatusResult(pin.Id, pin.Code, pin.ExpiresAtUtc, authorized);
+	}
+
+	public async Task<PlexAuthStatusResult> GetAuthStatusAsync(CancellationToken cancellationToken)
+	{
+		var account = await settingsRepo.GetAsync(new ServiceScope(ServiceType.Plex, PlexConstants.AccountServerId), cancellationToken);
+		return new PlexAuthStatusResult(
+			HasClientIdentifier: !string.IsNullOrWhiteSpace(account?.PlexClientIdentifier),
+			HasAuthToken: !string.IsNullOrWhiteSpace(account?.PlexAuthToken));
+	}
+
+	public async Task<IReadOnlyList<PlexServerRecord>> RefreshServersAsync(CancellationToken cancellationToken)
+	{
+		var account = await RequireAuthenticatedAsync(cancellationToken);
+		var servers = await authClient.GetServersAsync(account.PlexClientIdentifier!, account.PlexAuthToken!, cancellationToken);
+
+		var results = new List<PlexServerRecord>();
+		foreach (var server in servers)
+		{
+			var record = await UpsertServerAsync(server, account, cancellationToken);
+			results.Add(MapServer(record));
+		}
+
+		return results;
+	}
+
+	public async Task<IReadOnlyList<PlexServerRecord>> ListServersAsync(CancellationToken cancellationToken)
+	{
+		var rows = await settingsRepo.ListAsync(ServiceType.Plex, cancellationToken);
+		return rows
+			.Where(x => !string.Equals(x.ServerId, PlexConstants.AccountServerId, StringComparison.OrdinalIgnoreCase))
+			.Select(MapServer)
+			.ToList();
+	}
+
+	public async Task<PlexLibrarySyncResult> SyncLibraryAsync(ServiceScope scope, CancellationToken cancellationToken)
+	{
+		var settings = await RequireServerAsync(scope, cancellationToken);
+		var account = await EnsureAccountAsync(cancellationToken);
+		var accessToken = ResolveAccessToken(settings, account);
+
+		var connection = new PlexServerConnectionInfo(
+			settings.PlexServerUri!,
+			accessToken,
+			account.PlexClientIdentifier!);
+
+		var sections = await libraryClient.GetMovieSectionsAsync(connection, cancellationToken);
+		var tmdbIds = new HashSet<int>();
+		foreach (var section in sections)
+		{
+			var items = await libraryClient.GetLibraryItemsAsync(connection, section.Key, cancellationToken);
+			foreach (var item in items)
+			{
+				if (item.TmdbId > 0)
+				{
+					tmdbIds.Add(item.TmdbId);
+				}
+			}
+		}
+
+		var now = DateTimeOffset.UtcNow;
+		await libraryCache.ReplaceTmdbIdsAsync(scope, tmdbIds.ToList(), now, cancellationToken);
+		await UpdateServerAsync(settings, plexLastLibrarySyncUtc: now, cancellationToken: cancellationToken);
+
+		await EnrichTmdbAsync(tmdbIds, cancellationToken);
+
+		return new PlexLibrarySyncResult(tmdbIds.Count, now);
+	}
+
+	public async Task<PlexLibrarySyncResult?> EnsureLibrarySyncAsync(ServiceScope scope, CancellationToken cancellationToken)
+	{
+		var settings = await settingsRepo.GetAsync(scope, cancellationToken);
+		if (settings is null || string.IsNullOrWhiteSpace(settings.PlexServerUri))
+		{
+			return null;
+		}
+
+		var lastSync = settings.PlexLastLibrarySyncUtc;
+		var maxAge = TimeSpan.FromMinutes(Math.Clamp(_options.LibrarySyncMinutes, 1, 1440));
+		if (lastSync is null || DateTimeOffset.UtcNow - lastSync.Value >= maxAge)
+		{
+			return await SyncLibraryAsync(scope, cancellationToken);
+		}
+
+		return null;
+	}
+
+	public async Task<IReadOnlyList<MovieDetailsDto>> GetLibraryAsync(
+		ServiceScope scope,
+		UserPreferencesRecord preferences,
+		int limit,
+		CancellationToken cancellationToken)
+	{
+		limit = Math.Clamp(limit, 1, 200);
+		await EnsureLibrarySyncAsync(scope, cancellationToken);
+
+		var ids = await libraryCache.GetTmdbIdsAsync(scope, cancellationToken);
+		if (ids.Count == 0)
+		{
+			return [];
+		}
+
+		var results = new List<MovieDetailsDto>(limit);
+		foreach (var tmdbId in ids)
+		{
+			var details = await tmdbClient.GetMovieDetailsAsync(tmdbId, cancellationToken);
+			if (details is null)
+			{
+				continue;
+			}
+
+			if (!MatchesPreferences(details, preferences))
+			{
+				continue;
+			}
+
+			results.Add(details);
+			if (results.Count >= limit)
+			{
+				break;
+			}
+		}
+
+		return results;
+	}
+
+	private async Task<ServiceSettingsRecord> EnsureAccountAsync(CancellationToken cancellationToken)
+	{
+		var scope = new ServiceScope(ServiceType.Plex, PlexConstants.AccountServerId);
+		var existing = await settingsRepo.GetAsync(scope, cancellationToken);
+		if (existing is not null && !string.IsNullOrWhiteSpace(existing.PlexClientIdentifier))
+		{
+			return existing;
+		}
+
+		var clientId = existing?.PlexClientIdentifier;
+		if (string.IsNullOrWhiteSpace(clientId))
+		{
+			clientId = Guid.NewGuid().ToString("N");
+		}
+
+		var upsert = BuildUpsert(existing,
+			plexClientIdentifier: clientId,
+			plexAuthToken: existing?.PlexAuthToken);
+
+		await settingsRepo.UpsertAsync(scope, upsert, cancellationToken);
+		return await settingsRepo.GetAsync(scope, cancellationToken)
+			?? throw new InvalidOperationException("Plex account settings missing after upsert.");
+	}
+
+	private async Task<ServiceSettingsRecord> RequireAuthenticatedAsync(CancellationToken cancellationToken)
+	{
+		var account = await EnsureAccountAsync(cancellationToken);
+		if (string.IsNullOrWhiteSpace(account.PlexAuthToken))
+		{
+			throw new InvalidOperationException("Plex is not authenticated.");
+		}
+
+		return account;
+	}
+
+	private async Task<ServiceSettingsRecord> RequireServerAsync(ServiceScope scope, CancellationToken cancellationToken)
+	{
+		var settings = await settingsRepo.GetAsync(scope, cancellationToken);
+		if (settings is null || string.IsNullOrWhiteSpace(settings.PlexServerUri))
+		{
+			throw new InvalidOperationException("Plex server is not configured.");
+		}
+
+		return settings;
+	}
+
+	private async Task<ServiceSettingsRecord> UpsertServerAsync(PlexServerResource resource, ServiceSettingsRecord account, CancellationToken cancellationToken)
+	{
+		var scope = new ServiceScope(ServiceType.Plex, resource.MachineIdentifier);
+		var existing = await settingsRepo.GetAsync(scope, cancellationToken);
+
+		var selectedUri = SelectBestUri(resource);
+		var accessToken = string.IsNullOrWhiteSpace(resource.AccessToken) ? account.PlexAuthToken : resource.AccessToken;
+
+		var upsert = BuildUpsert(existing,
+			plexServerName: resource.Name,
+			plexServerUri: selectedUri,
+			plexServerVersion: resource.Version,
+			plexServerPlatform: resource.Platform,
+			plexServerOwned: resource.Owned,
+			plexServerOnline: resource.Online,
+			plexServerAccessToken: accessToken);
+
+		await settingsRepo.UpsertAsync(scope, upsert, cancellationToken);
+		return await settingsRepo.GetAsync(scope, cancellationToken)
+			?? throw new InvalidOperationException("Plex server settings missing after upsert.");
+	}
+
+	private Task UpdateAccountAsync(
+		ServiceSettingsRecord settings,
+		string? plexAuthToken = null,
+		CancellationToken cancellationToken = default)
+	{
+		var upsert = BuildUpsert(settings,
+			plexClientIdentifier: settings.PlexClientIdentifier,
+			plexAuthToken: plexAuthToken ?? settings.PlexAuthToken);
+
+		return settingsRepo.UpsertAsync(new ServiceScope(settings.ServiceType, settings.ServerId), upsert, cancellationToken);
+	}
+
+	private Task UpdateServerAsync(
+		ServiceSettingsRecord settings,
+		DateTimeOffset? plexLastLibrarySyncUtc = null,
+		CancellationToken cancellationToken = default)
+	{
+		var upsert = BuildUpsert(settings,
+			plexServerName: settings.PlexServerName,
+			plexServerUri: settings.PlexServerUri,
+			plexServerVersion: settings.PlexServerVersion,
+			plexServerPlatform: settings.PlexServerPlatform,
+			plexServerOwned: settings.PlexServerOwned,
+			plexServerOnline: settings.PlexServerOnline,
+			plexServerAccessToken: settings.PlexServerAccessToken,
+			plexLastLibrarySyncUtc: plexLastLibrarySyncUtc ?? settings.PlexLastLibrarySyncUtc);
+
+		return settingsRepo.UpsertAsync(new ServiceScope(settings.ServiceType, settings.ServerId), upsert, cancellationToken);
+	}
+
+	private static ServiceSettingsUpsert BuildUpsert(
+		ServiceSettingsRecord? existing,
+		string? plexClientIdentifier = null,
+		string? plexAuthToken = null,
+		string? plexServerName = null,
+		string? plexServerUri = null,
+		string? plexServerVersion = null,
+		string? plexServerPlatform = null,
+		bool? plexServerOwned = null,
+		bool? plexServerOnline = null,
+		string? plexServerAccessToken = null,
+		DateTimeOffset? plexLastLibrarySyncUtc = null)
+	{
+		return new ServiceSettingsUpsert(
+			RadarrBaseUrl: existing?.RadarrBaseUrl ?? string.Empty,
+			RadarrApiKey: existing?.RadarrApiKey ?? string.Empty,
+			RadarrQualityProfileId: existing?.RadarrQualityProfileId,
+			RadarrRootFolderPath: existing?.RadarrRootFolderPath,
+			RadarrTagLabel: existing?.RadarrTagLabel,
+			RadarrTagId: existing?.RadarrTagId,
+			RadarrAutoAddEnabled: existing?.RadarrAutoAddEnabled ?? false,
+			RadarrLastAutoAddAcceptedId: existing?.RadarrLastAutoAddAcceptedId,
+			RadarrLastLibrarySyncUtc: existing?.RadarrLastLibrarySyncUtc,
+			PlexClientIdentifier: plexClientIdentifier ?? existing?.PlexClientIdentifier,
+			PlexAuthToken: plexAuthToken ?? existing?.PlexAuthToken,
+			PlexServerName: plexServerName ?? existing?.PlexServerName,
+			PlexServerUri: plexServerUri ?? existing?.PlexServerUri,
+			PlexServerVersion: plexServerVersion ?? existing?.PlexServerVersion,
+			PlexServerPlatform: plexServerPlatform ?? existing?.PlexServerPlatform,
+			PlexServerOwned: plexServerOwned ?? existing?.PlexServerOwned,
+			PlexServerOnline: plexServerOnline ?? existing?.PlexServerOnline,
+			PlexServerAccessToken: plexServerAccessToken ?? existing?.PlexServerAccessToken,
+			PlexLastLibrarySyncUtc: plexLastLibrarySyncUtc ?? existing?.PlexLastLibrarySyncUtc);
+	}
+
+	private string ResolveAccessToken(ServiceSettingsRecord server, ServiceSettingsRecord account)
+	{
+		if (!string.IsNullOrWhiteSpace(server.PlexServerAccessToken))
+		{
+			return server.PlexServerAccessToken!;
+		}
+
+		if (string.IsNullOrWhiteSpace(account.PlexAuthToken))
+		{
+			throw new InvalidOperationException("Plex token is not available.");
+		}
+
+		return account.PlexAuthToken!;
+	}
+
+	private static string BuildAuthUrl(string clientIdentifier, string code)
+	{
+		var encodedClient = Uri.EscapeDataString(clientIdentifier);
+		var encodedCode = Uri.EscapeDataString(code);
+		return $"https://app.plex.tv/auth#?clientID={encodedClient}&code={encodedCode}";
+	}
+
+	private static string? SelectBestUri(PlexServerResource resource)
+	{
+		if (resource.Connections.Count == 0)
+		{
+			return null;
+		}
+
+		var ordered = resource.Connections
+			.OrderByDescending(c => c.Local)
+			.ThenByDescending(c => string.Equals(c.Protocol, "https", StringComparison.OrdinalIgnoreCase))
+			.ThenBy(c => c.Relay);
+
+		return ordered.FirstOrDefault()?.Uri;
+	}
+
+	private async Task EnrichTmdbAsync(IReadOnlyCollection<int> tmdbIds, CancellationToken cancellationToken)
+	{
+		if (tmdbIds.Count == 0)
+		{
+			return;
+		}
+
+		var maxConcurrency = Math.Clamp(_options.EnrichmentConcurrency, 1, 32);
+		using var gate = new SemaphoreSlim(maxConcurrency, maxConcurrency);
+		var tasks = tmdbIds.Select(async id =>
+		{
+			await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+			try
+			{
+				_ = await tmdbClient.GetMovieDetailsAsync(id, cancellationToken).ConfigureAwait(false);
+			}
+			catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+			{
+				logger.LogWarning(ex, "tmdb enrichment failed. TmdbId={TmdbId}", id);
+			}
+			finally
+			{
+				gate.Release();
+			}
+		}).ToList();
+
+		await Task.WhenAll(tasks).ConfigureAwait(false);
+	}
+
+	private static bool MatchesPreferences(MovieDetailsDto details, UserPreferencesRecord preferences)
+	{
+		if (preferences.MinReleaseYear is { } minYear)
+		{
+			if (details.ReleaseYear is null || details.ReleaseYear.Value < minYear)
+			{
+				return false;
+			}
+		}
+
+		if (preferences.MaxReleaseYear is { } maxYear)
+		{
+			if (details.ReleaseYear is null || details.ReleaseYear.Value > maxYear)
+			{
+				return false;
+			}
+		}
+
+		if (preferences.MinRating is { } minRating)
+		{
+			if (details.Rating is null || details.Rating.Value < minRating)
+			{
+				return false;
+			}
+		}
+
+		if (preferences.MaxRating is { } maxRating)
+		{
+			if (details.Rating is null || details.Rating.Value > maxRating)
+			{
+				return false;
+			}
+		}
+
+		if (!preferences.IncludeAdult && details.MpaaRating is not null && IsAdultRating(details.MpaaRating))
+		{
+			return false;
+		}
+
+		if (preferences.PreferredGenres is { Count: > 0 })
+		{
+			var preferred = MapGenreNames(preferences.PreferredGenres);
+			if (preferred.Count > 0 && !details.Genres.Any(g => preferred.Contains(g)))
+			{
+				return false;
+			}
+		}
+
+		if (preferences.ExcludedGenres is { Count: > 0 })
+		{
+			var excluded = MapGenreNames(preferences.ExcludedGenres);
+			if (excluded.Count > 0 && details.Genres.Any(g => excluded.Contains(g)))
+			{
+				return false;
+			}
+		}
+
+		if (preferences.PreferredRegions is { Count: > 0 })
+		{
+			if (!MatchesRegions(details.Regions, preferences.PreferredRegions))
+			{
+				return false;
+			}
+		}
+
+		if (preferences.PreferredOriginalLanguages is { Count: > 0 })
+		{
+			if (string.IsNullOrWhiteSpace(details.OriginalLanguage))
+			{
+				return false;
+			}
+
+			if (!preferences.PreferredOriginalLanguages.Contains(details.OriginalLanguage, StringComparer.OrdinalIgnoreCase))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static bool MatchesRegions(IReadOnlyList<string> regions, IReadOnlyList<string> preferredRegions)
+	{
+		if (preferredRegions.Count == 0)
+		{
+			return true;
+		}
+
+		if (regions.Count == 0)
+		{
+			return false;
+		}
+
+		var preferred = new HashSet<string>(preferredRegions, StringComparer.OrdinalIgnoreCase);
+		return regions.Any(r => preferred.Contains(r));
+	}
+
+	private static HashSet<string> MapGenreNames(IReadOnlyList<int> genreIds)
+	{
+		var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var id in genreIds)
+		{
+			if (TmdbGenreMap.TryGetValue(id, out var name))
+			{
+				names.Add(name);
+			}
+		}
+
+		return names;
+	}
+
+	private static bool IsAdultRating(string rating)
+	{
+		var normalized = rating.Trim().ToUpperInvariant();
+		return normalized is "NC-17" or "X" or "XXX" or "AO" or "ADULT";
+	}
+
+	private static PlexServerRecord MapServer(ServiceSettingsRecord settings)
+	{
+		return new PlexServerRecord(
+			settings.ServerId,
+			settings.PlexServerName ?? settings.ServerId,
+			settings.PlexServerUri,
+			settings.PlexServerVersion,
+			settings.PlexServerPlatform,
+			settings.PlexServerOwned,
+			settings.PlexServerOnline,
+			settings.PlexLastLibrarySyncUtc,
+			settings.UpdatedAtUtc);
+	}
+}

--- a/src/Tindarr.Application/Features/Radarr/RadarrService.cs
+++ b/src/Tindarr.Application/Features/Radarr/RadarrService.cs
@@ -78,7 +78,17 @@ public sealed class RadarrService(
 			RadarrTagId: tagId,
 			RadarrAutoAddEnabled: upsert.AutoAddEnabled,
 			RadarrLastAutoAddAcceptedId: existing?.RadarrLastAutoAddAcceptedId,
-			RadarrLastLibrarySyncUtc: lastLibrarySyncUtc);
+			RadarrLastLibrarySyncUtc: lastLibrarySyncUtc,
+			PlexClientIdentifier: existing?.PlexClientIdentifier,
+			PlexAuthToken: existing?.PlexAuthToken,
+			PlexServerName: existing?.PlexServerName,
+			PlexServerUri: existing?.PlexServerUri,
+			PlexServerVersion: existing?.PlexServerVersion,
+			PlexServerPlatform: existing?.PlexServerPlatform,
+			PlexServerOwned: existing?.PlexServerOwned,
+			PlexServerOnline: existing?.PlexServerOnline,
+			PlexServerAccessToken: existing?.PlexServerAccessToken,
+			PlexLastLibrarySyncUtc: existing?.PlexLastLibrarySyncUtc);
 
 		await settingsRepo.UpsertAsync(scope, upsertRecord, cancellationToken);
 		return await settingsRepo.GetAsync(scope, cancellationToken) ?? throw new InvalidOperationException("Radarr settings missing after upsert.");
@@ -305,7 +315,17 @@ public sealed class RadarrService(
 			radarrTagId ?? settings.RadarrTagId,
 			settings.RadarrAutoAddEnabled,
 			radarrLastAutoAddAcceptedId ?? settings.RadarrLastAutoAddAcceptedId,
-			radarrLastLibrarySyncUtc ?? settings.RadarrLastLibrarySyncUtc);
+			radarrLastLibrarySyncUtc ?? settings.RadarrLastLibrarySyncUtc,
+			settings.PlexClientIdentifier,
+			settings.PlexAuthToken,
+			settings.PlexServerName,
+			settings.PlexServerUri,
+			settings.PlexServerVersion,
+			settings.PlexServerPlatform,
+			settings.PlexServerOwned,
+			settings.PlexServerOnline,
+			settings.PlexServerAccessToken,
+			settings.PlexLastLibrarySyncUtc);
 
 		return settingsRepo.UpsertAsync(new ServiceScope(settings.ServiceType, settings.ServerId), upsert, cancellationToken);
 	}

--- a/src/Tindarr.Application/Interfaces/Integrations/IPlexService.cs
+++ b/src/Tindarr.Application/Interfaces/Integrations/IPlexService.cs
@@ -1,0 +1,55 @@
+using Tindarr.Application.Abstractions.Persistence;
+using Tindarr.Contracts.Movies;
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Application.Interfaces.Integrations;
+
+public interface IPlexService
+{
+	Task<PlexPinCreateResult> CreatePinAsync(CancellationToken cancellationToken);
+
+	Task<PlexPinStatusResult> VerifyPinAsync(long pinId, CancellationToken cancellationToken);
+
+	Task<PlexAuthStatusResult> GetAuthStatusAsync(CancellationToken cancellationToken);
+
+	Task<IReadOnlyList<PlexServerRecord>> RefreshServersAsync(CancellationToken cancellationToken);
+
+	Task<IReadOnlyList<PlexServerRecord>> ListServersAsync(CancellationToken cancellationToken);
+
+	Task<PlexLibrarySyncResult> SyncLibraryAsync(ServiceScope scope, CancellationToken cancellationToken);
+
+	Task<PlexLibrarySyncResult?> EnsureLibrarySyncAsync(ServiceScope scope, CancellationToken cancellationToken);
+
+	Task<IReadOnlyList<MovieDetailsDto>> GetLibraryAsync(
+		ServiceScope scope,
+		UserPreferencesRecord preferences,
+		int limit,
+		CancellationToken cancellationToken);
+}
+
+public sealed record PlexPinCreateResult(
+	long PinId,
+	string Code,
+	DateTimeOffset? ExpiresAtUtc,
+	string AuthUrl);
+
+public sealed record PlexPinStatusResult(
+	long PinId,
+	string Code,
+	DateTimeOffset? ExpiresAtUtc,
+	bool Authorized);
+
+public sealed record PlexAuthStatusResult(bool HasClientIdentifier, bool HasAuthToken);
+
+public sealed record PlexServerRecord(
+	string ServerId,
+	string Name,
+	string? BaseUrl,
+	string? Version,
+	string? Platform,
+	bool? Owned,
+	bool? Online,
+	DateTimeOffset? LastLibrarySyncUtc,
+	DateTimeOffset UpdatedAtUtc);
+
+public sealed record PlexLibrarySyncResult(int Count, DateTimeOffset SyncedAtUtc);

--- a/src/Tindarr.Application/Options/PlexOptions.cs
+++ b/src/Tindarr.Application/Options/PlexOptions.cs
@@ -1,0 +1,28 @@
+namespace Tindarr.Application.Options;
+
+public sealed class PlexOptions
+{
+	public const string SectionName = "Plex";
+
+	public int LibrarySyncMinutes { get; init; } = 15;
+
+	public int EnrichmentConcurrency { get; init; } = 4;
+
+	public string Product { get; init; } = "Tindarr";
+
+	public string Platform { get; init; } = "Tindarr";
+
+	public string Device { get; init; } = "Tindarr";
+
+	public string Version { get; init; } = "1.0";
+
+	public bool IsValid()
+	{
+		return LibrarySyncMinutes is >= 1 and <= 1440
+			&& EnrichmentConcurrency is >= 1 and <= 32
+			&& !string.IsNullOrWhiteSpace(Product)
+			&& !string.IsNullOrWhiteSpace(Platform)
+			&& !string.IsNullOrWhiteSpace(Device)
+			&& !string.IsNullOrWhiteSpace(Version);
+	}
+}

--- a/src/Tindarr.Application/Tindarr.Application.csproj
+++ b/src/Tindarr.Application/Tindarr.Application.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options">
       <Version>10.0.2</Version>
     </PackageReference>

--- a/src/Tindarr.Contracts/Movies/MovieDetailsDto.cs
+++ b/src/Tindarr.Contracts/Movies/MovieDetailsDto.cs
@@ -12,6 +12,7 @@ public sealed record MovieDetailsDto(
 	double? Rating,
 	int? VoteCount,
 	IReadOnlyList<string> Genres,
+	IReadOnlyList<string> Regions,
 	string? OriginalLanguage,
 	int? RuntimeMinutes);
 

--- a/src/Tindarr.Contracts/Plex/PlexAuthStatusResponse.cs
+++ b/src/Tindarr.Contracts/Plex/PlexAuthStatusResponse.cs
@@ -1,0 +1,5 @@
+namespace Tindarr.Contracts.Plex;
+
+public sealed record PlexAuthStatusResponse(
+	bool HasClientIdentifier,
+	bool HasAuthToken);

--- a/src/Tindarr.Contracts/Plex/PlexLibraryResponse.cs
+++ b/src/Tindarr.Contracts/Plex/PlexLibraryResponse.cs
@@ -1,0 +1,9 @@
+using Tindarr.Contracts.Movies;
+
+namespace Tindarr.Contracts.Plex;
+
+public sealed record PlexLibraryResponse(
+	string ServiceType,
+	string ServerId,
+	int Count,
+	IReadOnlyList<MovieDetailsDto> Items);

--- a/src/Tindarr.Contracts/Plex/PlexLibrarySyncResponse.cs
+++ b/src/Tindarr.Contracts/Plex/PlexLibrarySyncResponse.cs
@@ -1,0 +1,7 @@
+namespace Tindarr.Contracts.Plex;
+
+public sealed record PlexLibrarySyncResponse(
+	string ServiceType,
+	string ServerId,
+	int Count,
+	DateTimeOffset SyncedAtUtc);

--- a/src/Tindarr.Contracts/Plex/PlexPinCreateResponse.cs
+++ b/src/Tindarr.Contracts/Plex/PlexPinCreateResponse.cs
@@ -1,0 +1,7 @@
+namespace Tindarr.Contracts.Plex;
+
+public sealed record PlexPinCreateResponse(
+	long PinId,
+	string Code,
+	DateTimeOffset? ExpiresAtUtc,
+	string AuthUrl);

--- a/src/Tindarr.Contracts/Plex/PlexPinStatusResponse.cs
+++ b/src/Tindarr.Contracts/Plex/PlexPinStatusResponse.cs
@@ -1,0 +1,7 @@
+namespace Tindarr.Contracts.Plex;
+
+public sealed record PlexPinStatusResponse(
+	long PinId,
+	string Code,
+	DateTimeOffset? ExpiresAtUtc,
+	bool Authorized);

--- a/src/Tindarr.Contracts/Plex/PlexServerDto.cs
+++ b/src/Tindarr.Contracts/Plex/PlexServerDto.cs
@@ -1,0 +1,12 @@
+namespace Tindarr.Contracts.Plex;
+
+public sealed record PlexServerDto(
+	string ServerId,
+	string Name,
+	string? BaseUrl,
+	string? Version,
+	string? Platform,
+	bool? Owned,
+	bool? Online,
+	DateTimeOffset? LastLibrarySyncUtc,
+	DateTimeOffset UpdatedAtUtc);

--- a/src/Tindarr.Infrastructure/Integrations/Plex/PlexAuthClient.cs
+++ b/src/Tindarr.Infrastructure/Integrations/Plex/PlexAuthClient.cs
@@ -1,0 +1,186 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Tindarr.Application.Abstractions.Integrations;
+using Tindarr.Application.Options;
+
+namespace Tindarr.Infrastructure.Integrations.Plex;
+
+public sealed class PlexAuthClient(HttpClient httpClient, IOptions<PlexOptions> options, ILogger<PlexAuthClient> logger) : IPlexAuthClient
+{
+	private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+	private static readonly Uri PlexTvBaseUri = new("https://plex.tv/");
+	private readonly PlexOptions _options = options.Value;
+
+	public async Task<PlexPinResult> CreatePinAsync(string clientIdentifier, CancellationToken cancellationToken)
+	{
+		var request = new HttpRequestMessage(HttpMethod.Post, BuildPlexTvUri("api/v2/pins?strong=true"));
+		ApplyHeaders(request, clientIdentifier, authToken: null);
+
+		using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+		if (!response.IsSuccessStatusCode)
+		{
+			logger.LogWarning("plex pin request failed. Status={Status}", (int)response.StatusCode);
+			throw new HttpRequestException($"Plex PIN request failed. Status {(int)response.StatusCode} {response.StatusCode}.", null, response.StatusCode);
+		}
+
+		var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+		var parsed = JsonSerializer.Deserialize<PlexPinDto>(body, Json);
+		if (parsed is null || parsed.Id <= 0 || string.IsNullOrWhiteSpace(parsed.Code))
+		{
+			throw new HttpRequestException("Plex PIN response was invalid.");
+		}
+
+		return new PlexPinResult(parsed.Id, parsed.Code, parsed.ExpiresAt, parsed.AuthToken);
+	}
+
+	public async Task<PlexPinResult?> GetPinAsync(string clientIdentifier, long pinId, CancellationToken cancellationToken)
+	{
+		var request = new HttpRequestMessage(HttpMethod.Get, BuildPlexTvUri($"api/v2/pins/{pinId}"));
+		ApplyHeaders(request, clientIdentifier, authToken: null);
+
+		using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+		if (response.StatusCode == HttpStatusCode.NotFound)
+		{
+			return null;
+		}
+
+		if (!response.IsSuccessStatusCode)
+		{
+			logger.LogWarning("plex pin status failed. Status={Status}", (int)response.StatusCode);
+			throw new HttpRequestException($"Plex PIN status failed. Status {(int)response.StatusCode} {response.StatusCode}.", null, response.StatusCode);
+		}
+
+		var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+		var parsed = JsonSerializer.Deserialize<PlexPinDto>(body, Json);
+		if (parsed is null || parsed.Id <= 0 || string.IsNullOrWhiteSpace(parsed.Code))
+		{
+			return null;
+		}
+
+		return new PlexPinResult(parsed.Id, parsed.Code, parsed.ExpiresAt, parsed.AuthToken);
+	}
+
+	public async Task<PlexTokenValidationResult> ValidateTokenAsync(string clientIdentifier, string authToken, CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(authToken))
+		{
+			return new PlexTokenValidationResult(false, "Plex token is missing.");
+		}
+
+		var request = new HttpRequestMessage(HttpMethod.Get, BuildPlexTvUri("api/v2/user"));
+		ApplyHeaders(request, clientIdentifier, authToken);
+
+		using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+		if (response.IsSuccessStatusCode)
+		{
+			return new PlexTokenValidationResult(true, null);
+		}
+
+		if (response.StatusCode == HttpStatusCode.Unauthorized)
+		{
+			return new PlexTokenValidationResult(false, "Plex token rejected.");
+		}
+
+		return new PlexTokenValidationResult(false, $"Plex token validation failed. Status {(int)response.StatusCode} {response.StatusCode}.");
+	}
+
+	public async Task<IReadOnlyList<PlexServerResource>> GetServersAsync(string clientIdentifier, string authToken, CancellationToken cancellationToken)
+	{
+		var request = new HttpRequestMessage(HttpMethod.Get, BuildPlexTvUri("api/v2/resources?includeHttps=1&includeRelay=1&includeIPv6=1"));
+		ApplyHeaders(request, clientIdentifier, authToken);
+
+		using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+		if (!response.IsSuccessStatusCode)
+		{
+			logger.LogWarning("plex resources fetch failed. Status={Status}", (int)response.StatusCode);
+			throw new HttpRequestException($"Plex resources request failed. Status {(int)response.StatusCode} {response.StatusCode}.", null, response.StatusCode);
+		}
+
+		var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+		var parsed = JsonSerializer.Deserialize<List<PlexResourceDto>>(body, Json) ?? [];
+
+		var servers = new List<PlexServerResource>();
+		foreach (var resource in parsed)
+		{
+			if (resource is null || string.IsNullOrWhiteSpace(resource.MachineIdentifier))
+			{
+				continue;
+			}
+
+			if (string.IsNullOrWhiteSpace(resource.Provides) || !resource.Provides.Contains("server", StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+
+			var connections = resource.Connections?
+				.Where(c => !string.IsNullOrWhiteSpace(c.Uri))
+				.Select(c => new PlexServerConnection(
+					Uri: c.Uri!,
+					Local: c.Local ?? false,
+					Relay: c.Relay ?? false,
+					Protocol: string.IsNullOrWhiteSpace(c.Protocol) ? "http" : c.Protocol!))
+				.ToList() ?? [];
+
+			servers.Add(new PlexServerResource(
+				resource.MachineIdentifier!,
+				resource.Name ?? resource.MachineIdentifier!,
+				resource.ProductVersion,
+				resource.Platform,
+				resource.Owned ?? false,
+				resource.Presence ?? false,
+				resource.AccessToken,
+				connections));
+		}
+
+		return servers;
+	}
+
+	private void ApplyHeaders(HttpRequestMessage request, string clientIdentifier, string? authToken)
+	{
+		request.Headers.Accept.ParseAdd("application/json");
+		request.Headers.Add("X-Plex-Client-Identifier", clientIdentifier);
+		request.Headers.Add("X-Plex-Product", _options.Product);
+		request.Headers.Add("X-Plex-Platform", _options.Platform);
+		request.Headers.Add("X-Plex-Device", _options.Device);
+		request.Headers.Add("X-Plex-Version", _options.Version);
+		request.Headers.Add("X-Plex-Provides", "controller");
+
+		if (!string.IsNullOrWhiteSpace(authToken))
+		{
+			request.Headers.Add("X-Plex-Token", authToken);
+		}
+	}
+
+	private static Uri BuildPlexTvUri(string pathAndQuery)
+	{
+		var trimmed = pathAndQuery.TrimStart('/');
+		return new Uri(PlexTvBaseUri, trimmed);
+	}
+
+	private sealed record PlexPinDto(
+		[property: JsonPropertyName("id")] long Id,
+		[property: JsonPropertyName("code")] string? Code,
+		[property: JsonPropertyName("expiresAt")] DateTimeOffset? ExpiresAt,
+		[property: JsonPropertyName("authToken")] string? AuthToken);
+
+	private sealed record PlexResourceDto(
+		[property: JsonPropertyName("name")] string? Name,
+		[property: JsonPropertyName("clientIdentifier")] string? ClientIdentifier,
+		[property: JsonPropertyName("machineIdentifier")] string? MachineIdentifier,
+		[property: JsonPropertyName("accessToken")] string? AccessToken,
+		[property: JsonPropertyName("provides")] string? Provides,
+		[property: JsonPropertyName("owned")] bool? Owned,
+		[property: JsonPropertyName("presence")] bool? Presence,
+		[property: JsonPropertyName("productVersion")] string? ProductVersion,
+		[property: JsonPropertyName("platform")] string? Platform,
+		[property: JsonPropertyName("connections")] List<PlexConnectionDto>? Connections);
+
+	private sealed record PlexConnectionDto(
+		[property: JsonPropertyName("uri")] string? Uri,
+		[property: JsonPropertyName("protocol")] string? Protocol,
+		[property: JsonPropertyName("local")] bool? Local,
+		[property: JsonPropertyName("relay")] bool? Relay);
+}

--- a/src/Tindarr.Infrastructure/Integrations/Plex/PlexLibraryClient.cs
+++ b/src/Tindarr.Infrastructure/Integrations/Plex/PlexLibraryClient.cs
@@ -1,0 +1,205 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Tindarr.Application.Abstractions.Integrations;
+using Tindarr.Application.Options;
+
+namespace Tindarr.Infrastructure.Integrations.Plex;
+
+public sealed class PlexLibraryClient(HttpClient httpClient, IOptions<PlexOptions> options, ILogger<PlexLibraryClient> logger) : IPlexLibraryClient
+{
+	private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
+	{
+		PropertyNameCaseInsensitive = true
+	};
+
+	private readonly PlexOptions _options = options.Value;
+
+	private static readonly Regex TmdbIdRegex = new(@"tmdb[^\d]*(\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+	public async Task<IReadOnlyList<PlexLibrarySection>> GetMovieSectionsAsync(PlexServerConnectionInfo connection, CancellationToken cancellationToken)
+	{
+		var uri = BuildUri(connection.BaseUrl, "library/sections");
+		using var response = await SendAsync(connection, HttpMethod.Get, uri, cancellationToken).ConfigureAwait(false);
+
+		if (!response.IsSuccessStatusCode)
+		{
+			throw new HttpRequestException($"Plex library sections failed. Status {(int)response.StatusCode} {response.StatusCode}.", null, response.StatusCode);
+		}
+
+		var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+		var parsed = JsonSerializer.Deserialize<PlexContainer<PlexSectionsContainer>>(body, Json);
+		var sections = parsed?.MediaContainer?.Directory ?? [];
+
+		return sections
+			.Where(s => !string.IsNullOrWhiteSpace(s.Key) && !string.IsNullOrWhiteSpace(s.Type))
+			.Where(s => string.Equals(s.Type, "movie", StringComparison.OrdinalIgnoreCase))
+			.Select(s => new PlexLibrarySection(
+				Key: int.TryParse(s.Key, out var key) ? key : 0,
+				Title: string.IsNullOrWhiteSpace(s.Title) ? s.Key ?? "Movies" : s.Title,
+				Type: s.Type!))
+			.Where(s => s.Key > 0)
+			.ToList();
+	}
+
+	public async Task<IReadOnlyList<PlexLibraryItem>> GetLibraryItemsAsync(PlexServerConnectionInfo connection, int sectionKey, CancellationToken cancellationToken)
+	{
+		var uri = BuildUri(connection.BaseUrl, $"library/sections/{sectionKey}/all?includeGuids=1");
+		using var response = await SendAsync(connection, HttpMethod.Get, uri, cancellationToken).ConfigureAwait(false);
+
+		if (response.StatusCode == HttpStatusCode.NotFound)
+		{
+			return [];
+		}
+
+		if (!response.IsSuccessStatusCode)
+		{
+			throw new HttpRequestException($"Plex library fetch failed. Status {(int)response.StatusCode} {response.StatusCode}.", null, response.StatusCode);
+		}
+
+		var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+		var parsed = JsonSerializer.Deserialize<PlexContainer<PlexItemsContainer>>(body, Json);
+		var items = parsed?.MediaContainer?.Metadata ?? [];
+
+		var results = new List<PlexLibraryItem>(items.Count);
+		foreach (var item in items)
+		{
+			if (item is null)
+			{
+				continue;
+			}
+
+			var guid = ExtractGuid(item);
+			var tmdbId = TryParseTmdbId(item) ?? 0;
+			var title = string.IsNullOrWhiteSpace(item.Title) ? $"TMDB:{tmdbId}" : item.Title!.Trim();
+
+			if (tmdbId <= 0)
+			{
+				continue;
+			}
+
+			results.Add(new PlexLibraryItem(tmdbId, title, item.RatingKey, guid));
+		}
+
+		return results;
+	}
+
+	private async Task<HttpResponseMessage> SendAsync(PlexServerConnectionInfo connection, HttpMethod method, Uri uri, CancellationToken cancellationToken)
+	{
+		using var request = new HttpRequestMessage(method, uri);
+		request.Headers.Accept.ParseAdd("application/json");
+		request.Headers.Add("X-Plex-Client-Identifier", connection.ClientIdentifier);
+		request.Headers.Add("X-Plex-Product", _options.Product);
+		request.Headers.Add("X-Plex-Platform", _options.Platform);
+		request.Headers.Add("X-Plex-Device", _options.Device);
+		request.Headers.Add("X-Plex-Version", _options.Version);
+		request.Headers.Add("X-Plex-Token", connection.AccessToken);
+
+		try
+		{
+			return await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+		}
+		catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+		{
+			logger.LogWarning(ex, "plex library request failed. Uri={Uri}", uri);
+			throw;
+		}
+	}
+
+	private static Uri BuildUri(string baseUrl, string pathAndQuery)
+	{
+		var trimmedBase = (baseUrl ?? string.Empty).Trim().TrimEnd('/');
+		var trimmedPath = pathAndQuery.TrimStart('/');
+		return new Uri($"{trimmedBase}/{trimmedPath}", UriKind.Absolute);
+	}
+
+	private static int? TryParseTmdbId(PlexItemDto item)
+	{
+		foreach (var candidate in EnumerateGuids(item))
+		{
+			if (string.IsNullOrWhiteSpace(candidate))
+			{
+				continue;
+			}
+
+			if (!candidate.Contains("tmdb", StringComparison.OrdinalIgnoreCase)
+				&& !candidate.Contains("themoviedb", StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+
+			var direct = ExtractDigitsAfterScheme(candidate);
+			if (direct is not null)
+			{
+				return direct;
+			}
+
+			var match = TmdbIdRegex.Match(candidate);
+			if (match.Success && int.TryParse(match.Groups[1].Value, out var id))
+			{
+				return id;
+			}
+		}
+
+		return null;
+	}
+
+	private static int? ExtractDigitsAfterScheme(string candidate)
+	{
+		var idx = candidate.IndexOf("://", StringComparison.OrdinalIgnoreCase);
+		if (idx < 0)
+		{
+			return null;
+		}
+
+		var remainder = candidate[(idx + 3)..];
+		var digits = new string(remainder.TakeWhile(char.IsDigit).ToArray());
+		return int.TryParse(digits, out var id) ? id : null;
+	}
+
+	private static IEnumerable<string?> EnumerateGuids(PlexItemDto item)
+	{
+		if (!string.IsNullOrWhiteSpace(item.Guid))
+		{
+			yield return item.Guid;
+		}
+
+		if (item.GuidList is not null)
+		{
+			foreach (var guid in item.GuidList)
+			{
+				yield return guid?.Id;
+			}
+		}
+	}
+
+	private static string? ExtractGuid(PlexItemDto item)
+	{
+		return EnumerateGuids(item).FirstOrDefault(g => !string.IsNullOrWhiteSpace(g));
+	}
+
+	private sealed record PlexContainer<T>(
+		[property: JsonPropertyName("MediaContainer")] T? MediaContainer);
+
+	private sealed record PlexSectionsContainer(
+		[property: JsonPropertyName("Directory")] List<PlexSectionDto>? Directory);
+
+	private sealed record PlexSectionDto(
+		[property: JsonPropertyName("key")] string? Key,
+		[property: JsonPropertyName("title")] string? Title,
+		[property: JsonPropertyName("type")] string? Type);
+
+	private sealed record PlexItemsContainer(
+		[property: JsonPropertyName("Metadata")] List<PlexItemDto>? Metadata);
+
+	private sealed record PlexItemDto(
+		[property: JsonPropertyName("guid")] string? Guid,
+		[property: JsonPropertyName("Guid")] List<PlexGuidDto>? GuidList,
+		[property: JsonPropertyName("title")] string? Title,
+		[property: JsonPropertyName("ratingKey")] string? RatingKey);
+
+	private sealed record PlexGuidDto([property: JsonPropertyName("id")] string? Id);
+}

--- a/src/Tindarr.Infrastructure/Persistence/Configurations/ServiceSettingsEntityConfiguration.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Configurations/ServiceSettingsEntityConfiguration.cs
@@ -25,6 +25,17 @@ public sealed class ServiceSettingsEntityConfiguration : IEntityTypeConfiguratio
 		builder.Property(x => x.RadarrAutoAddEnabled).IsRequired();
 		builder.Property(x => x.RadarrLastAutoAddAcceptedId);
 		builder.Property(x => x.RadarrLastLibrarySyncUtc);
+
+		builder.Property(x => x.PlexClientIdentifier);
+		builder.Property(x => x.PlexAuthToken);
+		builder.Property(x => x.PlexServerName);
+		builder.Property(x => x.PlexServerUri);
+		builder.Property(x => x.PlexServerVersion);
+		builder.Property(x => x.PlexServerPlatform);
+		builder.Property(x => x.PlexServerOwned);
+		builder.Property(x => x.PlexServerOnline);
+		builder.Property(x => x.PlexServerAccessToken);
+		builder.Property(x => x.PlexLastLibrarySyncUtc);
 		builder.Property(x => x.UpdatedAtUtc).IsRequired();
 
 		builder.HasIndex(x => new { x.ServiceType, x.ServerId }).IsUnique();

--- a/src/Tindarr.Infrastructure/Persistence/Entities/ServiceSettingsEntity.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Entities/ServiceSettingsEntity.cs
@@ -18,5 +18,16 @@ public sealed class ServiceSettingsEntity
 	public bool RadarrAutoAddEnabled { get; set; }
 	public long? RadarrLastAutoAddAcceptedId { get; set; }
 	public DateTimeOffset? RadarrLastLibrarySyncUtc { get; set; }
+
+	public string? PlexClientIdentifier { get; set; }
+	public string? PlexAuthToken { get; set; }
+	public string? PlexServerName { get; set; }
+	public string? PlexServerUri { get; set; }
+	public string? PlexServerVersion { get; set; }
+	public string? PlexServerPlatform { get; set; }
+	public bool? PlexServerOwned { get; set; }
+	public bool? PlexServerOnline { get; set; }
+	public string? PlexServerAccessToken { get; set; }
+	public DateTimeOffset? PlexLastLibrarySyncUtc { get; set; }
 	public DateTimeOffset UpdatedAtUtc { get; set; }
 }

--- a/src/Tindarr.Infrastructure/Persistence/Migrations/20260128040000_AddPlexFieldsToServiceSettings.Designer.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Migrations/20260128040000_AddPlexFieldsToServiceSettings.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Tindarr.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using Tindarr.Infrastructure.Persistence;
 namespace Tindarr.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(TindarrDbContext))]
-    partial class TindarrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260128040000_AddPlexFieldsToServiceSettings")]
+    partial class AddPlexFieldsToServiceSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.23");

--- a/src/Tindarr.Infrastructure/Persistence/Migrations/20260128040000_AddPlexFieldsToServiceSettings.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Migrations/20260128040000_AddPlexFieldsToServiceSettings.cs
@@ -1,0 +1,119 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tindarr.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlexFieldsToServiceSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PlexAuthToken",
+                table: "service_settings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PlexClientIdentifier",
+                table: "service_settings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "PlexLastLibrarySyncUtc",
+                table: "service_settings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PlexServerAccessToken",
+                table: "service_settings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PlexServerName",
+                table: "service_settings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "PlexServerOnline",
+                table: "service_settings",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "PlexServerOwned",
+                table: "service_settings",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PlexServerPlatform",
+                table: "service_settings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PlexServerUri",
+                table: "service_settings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PlexServerVersion",
+                table: "service_settings",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PlexAuthToken",
+                table: "service_settings");
+
+            migrationBuilder.DropColumn(
+                name: "PlexClientIdentifier",
+                table: "service_settings");
+
+            migrationBuilder.DropColumn(
+                name: "PlexLastLibrarySyncUtc",
+                table: "service_settings");
+
+            migrationBuilder.DropColumn(
+                name: "PlexServerAccessToken",
+                table: "service_settings");
+
+            migrationBuilder.DropColumn(
+                name: "PlexServerName",
+                table: "service_settings");
+
+            migrationBuilder.DropColumn(
+                name: "PlexServerOnline",
+                table: "service_settings");
+
+            migrationBuilder.DropColumn(
+                name: "PlexServerOwned",
+                table: "service_settings");
+
+            migrationBuilder.DropColumn(
+                name: "PlexServerPlatform",
+                table: "service_settings");
+
+            migrationBuilder.DropColumn(
+                name: "PlexServerUri",
+                table: "service_settings");
+
+            migrationBuilder.DropColumn(
+                name: "PlexServerVersion",
+                table: "service_settings");
+        }
+    }
+}

--- a/src/Tindarr.Infrastructure/Persistence/Repositories/ServiceSettingsRepository.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Repositories/ServiceSettingsRepository.cs
@@ -49,6 +49,16 @@ public sealed class ServiceSettingsRepository(TindarrDbContext db) : IServiceSet
 				RadarrAutoAddEnabled = upsert.RadarrAutoAddEnabled,
 				RadarrLastAutoAddAcceptedId = upsert.RadarrLastAutoAddAcceptedId,
 				RadarrLastLibrarySyncUtc = upsert.RadarrLastLibrarySyncUtc,
+				PlexClientIdentifier = upsert.PlexClientIdentifier,
+				PlexAuthToken = upsert.PlexAuthToken,
+				PlexServerName = upsert.PlexServerName,
+				PlexServerUri = upsert.PlexServerUri,
+				PlexServerVersion = upsert.PlexServerVersion,
+				PlexServerPlatform = upsert.PlexServerPlatform,
+				PlexServerOwned = upsert.PlexServerOwned,
+				PlexServerOnline = upsert.PlexServerOnline,
+				PlexServerAccessToken = upsert.PlexServerAccessToken,
+				PlexLastLibrarySyncUtc = upsert.PlexLastLibrarySyncUtc,
 				UpdatedAtUtc = now
 			};
 
@@ -65,6 +75,16 @@ public sealed class ServiceSettingsRepository(TindarrDbContext db) : IServiceSet
 			entity.RadarrAutoAddEnabled = upsert.RadarrAutoAddEnabled;
 			entity.RadarrLastAutoAddAcceptedId = upsert.RadarrLastAutoAddAcceptedId;
 			entity.RadarrLastLibrarySyncUtc = upsert.RadarrLastLibrarySyncUtc;
+			entity.PlexClientIdentifier = upsert.PlexClientIdentifier;
+			entity.PlexAuthToken = upsert.PlexAuthToken;
+			entity.PlexServerName = upsert.PlexServerName;
+			entity.PlexServerUri = upsert.PlexServerUri;
+			entity.PlexServerVersion = upsert.PlexServerVersion;
+			entity.PlexServerPlatform = upsert.PlexServerPlatform;
+			entity.PlexServerOwned = upsert.PlexServerOwned;
+			entity.PlexServerOnline = upsert.PlexServerOnline;
+			entity.PlexServerAccessToken = upsert.PlexServerAccessToken;
+			entity.PlexLastLibrarySyncUtc = upsert.PlexLastLibrarySyncUtc;
 			entity.UpdatedAtUtc = now;
 		}
 
@@ -85,6 +105,16 @@ public sealed class ServiceSettingsRepository(TindarrDbContext db) : IServiceSet
 			entity.RadarrAutoAddEnabled,
 			entity.RadarrLastAutoAddAcceptedId,
 			entity.RadarrLastLibrarySyncUtc,
+			entity.PlexClientIdentifier,
+			entity.PlexAuthToken,
+			entity.PlexServerName,
+			entity.PlexServerUri,
+			entity.PlexServerVersion,
+			entity.PlexServerPlatform,
+			entity.PlexServerOwned,
+			entity.PlexServerOnline,
+			entity.PlexServerAccessToken,
+			entity.PlexLastLibrarySyncUtc,
 			entity.UpdatedAtUtc);
 	}
 }

--- a/src/Tindarr.Workers/Jobs/PlexLibrarySyncWorker.cs
+++ b/src/Tindarr.Workers/Jobs/PlexLibrarySyncWorker.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Tindarr.Application.Abstractions.Integrations;
+using Tindarr.Application.Abstractions.Persistence;
+using Tindarr.Application.Interfaces.Integrations;
+using Tindarr.Application.Options;
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Workers.Jobs;
+
+/// <summary>
+/// Periodically syncs Plex library cache and TMDB enrichment.
+/// </summary>
+public sealed class PlexLibrarySyncWorker(
+	IServiceScopeFactory scopeFactory,
+	IOptions<PlexOptions> options,
+	ILogger<PlexLibrarySyncWorker> logger) : PeriodicBackgroundService(logger)
+{
+	private readonly IServiceScopeFactory _scopeFactory = scopeFactory;
+	private readonly PlexOptions _options = options.Value;
+
+	protected override TimeSpan Interval => TimeSpan.FromMinutes(Math.Clamp(_options.LibrarySyncMinutes, 1, 1440));
+
+	protected override TimeSpan InitialDelay => TimeSpan.FromSeconds(15);
+
+	protected override async Task ExecuteOnceAsync(CancellationToken stoppingToken)
+	{
+		using var scope = _scopeFactory.CreateScope();
+		var settingsRepo = scope.ServiceProvider.GetRequiredService<IServiceSettingsRepository>();
+		var plexService = scope.ServiceProvider.GetRequiredService<IPlexService>();
+
+		var settings = await settingsRepo.ListAsync(ServiceType.Plex, stoppingToken);
+		if (settings.Count == 0)
+		{
+			Logger.LogDebug("plex library sync tick (no settings)");
+			return;
+		}
+
+		foreach (var entry in settings)
+		{
+			if (string.Equals(entry.ServerId, PlexConstants.AccountServerId, StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+
+			var serviceScope = new ServiceScope(entry.ServiceType, entry.ServerId);
+			await plexService.EnsureLibrarySyncAsync(serviceScope, stoppingToken);
+		}
+	}
+}

--- a/src/Tindarr.Workers/Program.cs
+++ b/src/Tindarr.Workers/Program.cs
@@ -2,14 +2,20 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Hosting.WindowsServices;
+using Tindarr.Application.Abstractions.Caching;
 using Tindarr.Application.Abstractions.Integrations;
 using Tindarr.Application.Abstractions.Persistence;
+using Tindarr.Application.Features.Plex;
 using Tindarr.Application.Features.Radarr;
 using Tindarr.Application.Interfaces.Integrations;
 using Tindarr.Application.Interfaces.Ops;
 using Tindarr.Application.Options;
 using Tindarr.Application.Services;
+using Tindarr.Infrastructure.Caching;
+using Tindarr.Infrastructure.Integrations.Plex;
 using Tindarr.Infrastructure.Integrations.Radarr;
+using Tindarr.Infrastructure.Integrations.Tmdb;
+using Tindarr.Infrastructure.Integrations.Tmdb.Http;
 using Tindarr.Infrastructure.Persistence;
 using Tindarr.Infrastructure.Persistence.Repositories;
 using Tindarr.Workers.Jobs;
@@ -21,6 +27,12 @@ var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
 	Args = args,
 	ContentRootPath = isWindowsService ? AppContext.BaseDirectory : null
 });
+
+var tmdbApiKeyEnv = Environment.GetEnvironmentVariable("TMDB_API_KEY");
+if (!string.IsNullOrWhiteSpace(tmdbApiKeyEnv) && string.IsNullOrWhiteSpace(builder.Configuration["Tmdb:ApiKey"]))
+{
+	builder.Configuration["Tmdb:ApiKey"] = tmdbApiKeyEnv;
+}
 
 if (isWindowsService)
 {
@@ -38,9 +50,19 @@ builder.Services.AddOptions<DatabaseOptions>()
 	.Validate(o => o.IsValid(), "Invalid Database configuration.")
 	.ValidateOnStart();
 
+builder.Services.AddOptions<TmdbOptions>()
+	.BindConfiguration(TmdbOptions.SectionName)
+	.Validate(o => o.IsValid(), "Invalid Tmdb configuration.")
+	.ValidateOnStart();
+
 builder.Services.AddOptions<RadarrOptions>()
 	.BindConfiguration(RadarrOptions.SectionName)
 	.Validate(o => o.IsValid(), "Invalid Radarr configuration.")
+	.ValidateOnStart();
+
+builder.Services.AddOptions<PlexOptions>()
+	.BindConfiguration(PlexOptions.SectionName)
+	.Validate(o => o.IsValid(), "Invalid Plex configuration.")
 	.ValidateOnStart();
 
 builder.Services.AddSingleton<IBaseUrlResolver>(sp =>
@@ -55,8 +77,37 @@ builder.Services.AddScoped<IAcceptedMovieRepository, AcceptedMovieRepository>();
 builder.Services.AddScoped<IServiceSettingsRepository, ServiceSettingsRepository>();
 builder.Services.AddScoped<ILibraryCacheRepository, LibraryCacheRepository>();
 builder.Services.AddScoped<IRadarrService, RadarrService>();
+builder.Services.AddScoped<IPlexService, PlexService>();
 
 builder.Services.AddHttpClient<IRadarrClient, RadarrClient>();
+builder.Services.AddHttpClient<IPlexAuthClient, PlexAuthClient>();
+builder.Services.AddHttpClient<IPlexLibraryClient, PlexLibraryClient>();
+
+builder.Services.AddMemoryCache();
+builder.Services.AddSingleton<ITmdbCache>(sp =>
+{
+	var tmdbMetadataDbPath = Path.Combine(builder.Environment.ContentRootPath, "tmdbmetadata.db");
+	return new MemoryOrDbTmdbCache(sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>(), tmdbMetadataDbPath);
+});
+builder.Services.AddSingleton<ITmdbRateLimiter, TokenBucketRateLimiter>();
+builder.Services.AddTransient<TmdbCachingHandler>();
+builder.Services.AddTransient<TmdbRateLimitingHandler>();
+
+builder.Services.AddHttpClient<ITmdbClient, TmdbClient>((sp, client) =>
+{
+	var tmdb = sp.GetRequiredService<IOptions<TmdbOptions>>().Value;
+	client.BaseAddress = new Uri(tmdb.BaseUrl);
+	client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+
+	if (!string.IsNullOrWhiteSpace(tmdb.ReadAccessToken))
+	{
+		client.DefaultRequestHeaders.Authorization =
+			new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", tmdb.ReadAccessToken);
+	}
+})
+.AddHttpMessageHandler<TmdbCachingHandler>()
+.AddHttpMessageHandler<TmdbRateLimitingHandler>()
+.AddHttpMessageHandler(() => new TmdbRetryHandler(maxRetries: 3));
 
 // Core-only worker stubs (periodic background services).
 builder.Services.AddHostedService<OutboxWorker>();
@@ -64,6 +115,7 @@ builder.Services.AddHostedService<TmdbMetadataWorker>();
 builder.Services.AddHostedService<MatchComputationWorker>();
 builder.Services.AddHostedService<MediaServerSyncWorker>();
 builder.Services.AddHostedService<RadarrAutoAddWorker>();
+builder.Services.AddHostedService<PlexLibrarySyncWorker>();
 builder.Services.AddHostedService<CleanupWorker>();
 builder.Services.AddHostedService<HealthHeartbeatWorker>();
 builder.Services.AddHostedService<RecommendationWorker>();

--- a/src/Tindarr.Workers/Tindarr.Workers.csproj
+++ b/src/Tindarr.Workers/Tindarr.Workers.csproj
@@ -13,10 +13,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting">
       <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
   </ItemGroup>
 </Project>

--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -91,6 +91,7 @@ export type MovieDetailsDto = {
   rating: number | null;
   voteCount: number | null;
   genres: string[];
+  regions: string[];
   originalLanguage: string | null;
   runtimeMinutes: number | null;
 };


### PR DESCRIPTION
## Summary by Sourcery

Introduce Plex media server integration, including authentication, server discovery, library syncing, and Plex-backed library access filtered by user preferences, while enriching TMDB metadata with region information.

New Features:
- Add Plex API endpoints for authentication via PIN, server listing/sync, and library retrieval and sync.
- Implement Plex authentication and library HTTP clients and a PlexService coordinating Plex account, server management, and library syncing with TMDB enrichment.
- Expose Plex servers and library data via new contracts and integrate Plex into the API and worker hosts, including a periodic Plex library sync worker.
- Extend movie details and user preferences handling to support TMDB-derived release regions and region-based filtering.

Enhancements:
- Extend service settings persistence to store Plex account, server connection, and library sync metadata.
- Enhance TMDB client to extract and return distinct release regions for movies.
- Wire TMDB configuration from environment variables in workers and add TMDB caching, rate limiting, and retry pipeline there to match the API setup.