### PR TITLE
Add casting + playback proxy and Plex cache tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ ui/dist/
 ui/.vite/
 ui/.turbo/
 
+# Generated UI build output copied into API wwwroot
+src/Tindarr.Api/wwwroot/assets/
+src/Tindarr.Api/wwwroot/index.html
+
 # Build artifacts (local publish, MSI outputs, logs)
 artifacts/
 

--- a/src/Tindarr.Api/Controllers/CastingController.cs
+++ b/src/Tindarr.Api/Controllers/CastingController.cs
@@ -1,0 +1,554 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Options;
+using QRCoder;
+using System.Net;
+using System.Net.NetworkInformation;
+using Tindarr.Api.Auth;
+using Tindarr.Application.Abstractions.Persistence;
+using Tindarr.Application.Abstractions.Security;
+using Tindarr.Application.Interfaces.Playback;
+using Tindarr.Application.Interfaces.Casting;
+using Tindarr.Application.Interfaces.Ops;
+using Tindarr.Application.Interfaces.Rooms;
+using Tindarr.Application.Options;
+using Tindarr.Contracts.Casting;
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Api.Controllers;
+
+[ApiController]
+[Route("api/v1/casting")]
+public sealed class CastingController(
+	ICastClient castClient,
+	ICastUrlTokenService castUrlTokenService,
+	IPlaybackTokenService playbackTokenService,
+	IEnumerable<IPlaybackProvider> playbackProviders,
+	IRoomService roomService,
+	IBaseUrlResolver baseUrlResolver,
+	IJoinAddressSettingsRepository joinAddressSettings,
+	IOptions<BaseUrlOptions> baseUrlOptions,
+	ILogger<CastingController> logger) : ControllerBase
+{
+	[HttpGet("devices")]
+	[Authorize]
+	public async Task<ActionResult<IReadOnlyList<CastDeviceDto>>> ListDevices(CancellationToken cancellationToken)
+	{
+		var devices = await castClient.DiscoverAsync(cancellationToken).ConfigureAwait(false);
+		var dtos = devices
+			.Select(d => new CastDeviceDto(d.Id, d.Name, d.Address, d.Port))
+			.ToList();
+		return Ok(dtos);
+	}
+
+	[HttpGet("rooms/{roomId}/qr.png")]
+	[AllowAnonymous]
+	public async Task<IActionResult> GetRoomQrPng(
+		[FromRoute] string roomId,
+		[FromQuery] string? token,
+		CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(roomId))
+		{
+			return BadRequest("Room id is required.");
+		}
+
+		if (string.IsNullOrWhiteSpace(token) || !castUrlTokenService.TryValidateRoomQrToken(token, roomId, DateTimeOffset.UtcNow))
+		{
+			return Unauthorized();
+		}
+
+		var room = await roomService.GetAsync(roomId, cancellationToken).ConfigureAwait(false);
+		if (room is null)
+		{
+			return NotFound("Room not found.");
+		}
+
+		var joinUrl = await BuildJoinUrlAsync(room.RoomId, cancellationToken).ConfigureAwait(false);
+		if (joinUrl is null)
+		{
+			return BadRequest("Join URL base is not configured. Ask an admin to set LAN/WAN join address in Admin Console.");
+		}
+
+		var bytes = BuildQrPng(joinUrl);
+		return File(bytes, "image/png");
+	}
+
+	[HttpPost("rooms/{roomId}/qr")]
+	[Authorize]
+	public async Task<IActionResult> CastRoomQr(
+		[FromRoute] string roomId,
+		[FromBody] CastQrRequest request,
+		CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(request.DeviceId))
+		{
+			return BadRequest("DeviceId is required.");
+		}
+		if (string.IsNullOrWhiteSpace(roomId))
+		{
+			return BadRequest("Room id is required.");
+		}
+
+		var room = await roomService.GetAsync(roomId, cancellationToken).ConfigureAwait(false);
+		if (room is null)
+		{
+			return NotFound("Room not found.");
+		}
+
+		var baseUri = await ResolveCastFetchBaseUriAsync(cancellationToken).ConfigureAwait(false);
+		if (baseUri is null)
+		{
+			return BadRequest("LAN cast base URL is not configured. Ask an admin to set LAN join address in Admin Console or configure 'BaseUrl:Lan'.");
+		}
+
+		var token = castUrlTokenService.IssueRoomQrToken(roomId, DateTimeOffset.UtcNow);
+		var qrUrl = new Uri(baseUri, $"api/v1/casting/rooms/{Uri.EscapeDataString(roomId)}/qr.png?token={Uri.EscapeDataString(token)}");
+		logger.LogInformation("Casting room QR to device {DeviceId}: {Url}", request.DeviceId, qrUrl);
+		Response.Headers["X-Tindarr-Cast-Url"] = qrUrl.ToString();
+		var serverUrls = GetServerUrlsHeaderValue();
+		if (!string.IsNullOrWhiteSpace(serverUrls))
+		{
+			Response.Headers["X-Tindarr-Server-Urls"] = serverUrls;
+		}
+		if (!IsServerListeningOnNonLoopback())
+		{
+			return BadRequest("API is only listening on localhost. Chromecast cannot reach it. Start the API with '--urls http://0.0.0.0:<port>' (or bind to your LAN IP) and allow the port through Windows Firewall.");
+		}
+
+		await castClient.CastAsync(request.DeviceId, new CastMedia(
+			ContentUrl: qrUrl.ToString(),
+			ContentType: "image/png",
+			Title: "Join room",
+			SubTitle: roomId), cancellationToken).ConfigureAwait(false);
+
+		return Ok();
+	}
+
+	[HttpPost("movie")]
+	[Authorize]
+	public async Task<IActionResult> CastMovie([FromBody] CastMovieRequest request, CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(request.DeviceId))
+		{
+			return BadRequest("DeviceId is required.");
+		}
+		if (request.TmdbId <= 0)
+		{
+			return BadRequest("TmdbId must be positive.");
+		}
+
+		if (!ServiceScope.TryCreate(request.ServiceType, request.ServerId, out var scope) || scope is null)
+		{
+			return BadRequest("ServiceType and ServerId are required.");
+		}
+
+		var title = string.IsNullOrWhiteSpace(request.Title) ? $"TMDB:{request.TmdbId}" : request.Title.Trim();
+
+		// Plex special-case:
+		// Prefer casting a *direct Plex transcode URL* so Plex streams bytes straight to the Chromecast.
+		// This avoids Tindarr proxying the media.
+		if (scope.ServiceType == ServiceType.Plex)
+		{
+			var provider = playbackProviders.FirstOrDefault(p => p.ServiceType == ServiceType.Plex);
+			if (provider is null)
+			{
+				return BadRequest("Unsupported playback provider.");
+			}
+
+			UpstreamPlaybackRequest upstream;
+			try
+			{
+				upstream = await provider.BuildMovieStreamRequestAsync(scope, request.TmdbId, cancellationToken).ConfigureAwait(false);
+			}
+			catch (InvalidOperationException ex)
+			{
+				return BadRequest(ex.Message);
+			}
+
+			// Chromecast won't send our headers, so encode the essential X-Plex-* headers as query params.
+			// IMPORTANT: Do not echo the token back in response headers/logs.
+			var plexDirectUrl = BuildPlexDirectCastUrl(upstream);
+			var redacted = new UriBuilder(plexDirectUrl) { Query = string.Empty }.Uri;
+			logger.LogInformation("Casting Plex movie directly to device {DeviceId}: {Url}", request.DeviceId, redacted);
+			Response.Headers["X-Tindarr-Cast-Url"] = redacted.ToString();
+
+			await castClient.CastAsync(request.DeviceId, new CastMedia(
+				ContentUrl: plexDirectUrl.ToString(),
+				ContentType: "video/mp4",
+				Title: title,
+				SubTitle: scope.ServiceType.ToString()), cancellationToken).ConfigureAwait(false);
+
+			return Ok();
+		}
+
+		var baseUri = await ResolveCastFetchBaseUriAsync(cancellationToken).ConfigureAwait(false);
+		if (baseUri is null)
+		{
+			return BadRequest("LAN cast base URL is not configured. Ask an admin to set LAN join address in Admin Console or configure 'BaseUrl:Lan'.");
+		}
+
+		var token = playbackTokenService.IssueMovieToken(scope, request.TmdbId, DateTimeOffset.UtcNow);
+		var playbackUrl = new Uri(baseUri, $"api/v1/playback/movie/{Uri.EscapeDataString(scope.ServiceType.ToString().ToLowerInvariant())}/{Uri.EscapeDataString(scope.ServerId)}/{request.TmdbId}?token={Uri.EscapeDataString(token)}");
+		logger.LogInformation("Casting movie to device {DeviceId}: {Url}", request.DeviceId, playbackUrl);
+		Response.Headers["X-Tindarr-Cast-Url"] = playbackUrl.ToString();
+		var serverUrls = GetServerUrlsHeaderValue();
+		if (!string.IsNullOrWhiteSpace(serverUrls))
+		{
+			Response.Headers["X-Tindarr-Server-Urls"] = serverUrls;
+		}
+		if (!IsServerListeningOnNonLoopback())
+		{
+			return BadRequest("API is only listening on localhost. Chromecast cannot reach it. Start the API with '--urls http://0.0.0.0:<port>' (or bind to your LAN IP) and allow the port through Windows Firewall.");
+		}
+
+		try
+		{
+			await castClient.CastAsync(request.DeviceId, new CastMedia(
+				ContentUrl: playbackUrl.ToString(),
+				ContentType: "video/mp4",
+				Title: title,
+				SubTitle: scope.ServiceType.ToString()), cancellationToken).ConfigureAwait(false);
+		}
+		catch (Exception ex)
+		{
+			logger.LogWarning(ex, "cast movie failed");
+			throw;
+		}
+
+		return Ok();
+	}
+
+	private static Uri BuildPlexDirectCastUrl(UpstreamPlaybackRequest upstream)
+	{
+		// Plex endpoints accept X-Plex-Token as a query parameter; encoding the client identity/profile
+		// similarly allows Plex to select the right transcode profile without relying on request headers.
+		var queryParams = new Dictionary<string, string>(StringComparer.Ordinal);
+		foreach (var header in upstream.Headers)
+		{
+			if (!header.Key.StartsWith("X-Plex-", StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+			if (string.IsNullOrWhiteSpace(header.Value))
+			{
+				continue;
+			}
+
+			queryParams[header.Key] = header.Value;
+		}
+
+		var url = QueryHelpers.AddQueryString(upstream.Uri.ToString(), queryParams);
+		return new Uri(url, UriKind.Absolute);
+	}
+
+	private async Task<string?> BuildJoinUrlAsync(string roomId, CancellationToken cancellationToken)
+	{
+		var baseUri = await ResolveJoinBaseUriAsync(cancellationToken).ConfigureAwait(false);
+		if (baseUri is null)
+		{
+			// If join base isn't configured, fall back to LAN-only base so the QR image can still render.
+			baseUri = await ResolveCastFetchBaseUriAsync(cancellationToken).ConfigureAwait(false);
+		}
+		if (baseUri is null)
+		{
+			return null;
+		}
+
+		return new Uri(baseUri, $"rooms/{Uri.EscapeDataString(roomId)}").ToString();
+	}
+
+	private async Task<Uri?> ResolveCastFetchBaseUriAsync(CancellationToken cancellationToken)
+	{
+		// Chromecast fetches media from the server: always prefer LAN.
+		var settings = await joinAddressSettings.GetAsync(cancellationToken).ConfigureAwait(false);
+		var lanHostPort = settings?.LanHostPort;
+		var wanHostPort = settings?.WanHostPort;
+
+		var requestPort = Request.Host.Port;
+		if (!string.IsNullOrWhiteSpace(lanHostPort))
+		{
+			var hostPort = lanHostPort.Trim().TrimEnd('/');
+			var scheme = ResolveJoinScheme(hostPort, lanHostPort, wanHostPort, baseUrlOptions.Value, Request.Scheme);
+			var uri = new Uri($"{scheme}://{hostPort}/", UriKind.Absolute);
+			return RewriteLoopbackToLanIp(uri, requestPort);
+		}
+
+		if (!string.IsNullOrWhiteSpace(baseUrlOptions.Value.Lan)
+			&& Uri.TryCreate(baseUrlOptions.Value.Lan.Trim(), UriKind.Absolute, out var lanUri)
+			&& lanUri.Scheme is "http" or "https")
+		{
+			return RewriteLoopbackToLanIp(lanUri, requestPort);
+		}
+
+		// Last-resort fallback: use current request host if it isn't loopback.
+		if (Request.Host.HasValue
+			&& (Request.Scheme is "http" or "https")
+			&& !string.Equals(Request.Host.Host, "localhost", StringComparison.OrdinalIgnoreCase)
+			&& !string.Equals(Request.Host.Host, "127.0.0.1", StringComparison.OrdinalIgnoreCase)
+			&& !string.Equals(Request.Host.Host, "::1", StringComparison.OrdinalIgnoreCase))
+		{
+			return new Uri($"{Request.Scheme}://{Request.Host.Value}/", UriKind.Absolute);
+		}
+
+		// If we're bound to localhost (common in dev), attempt to substitute a LAN IP.
+		if (Request.Host.HasValue && (Request.Scheme is "http" or "https"))
+		{
+			var candidate = new Uri($"{Request.Scheme}://{Request.Host.Value}/", UriKind.Absolute);
+			var rewritten = RewriteLoopbackToLanIp(candidate, requestPort);
+			if (rewritten is not null)
+			{
+				return rewritten;
+			}
+		}
+
+		return null;
+	}
+
+	private static Uri? RewriteLoopbackToLanIp(Uri uri, int? preferredPort)
+	{
+		if (!IsLoopbackHost(uri.Host))
+		{
+			return uri;
+		}
+
+		var lanIp = TryGetPrivateIPv4();
+		if (lanIp is null)
+		{
+			return null;
+		}
+
+		var builder = new UriBuilder(uri)
+		{
+			Host = lanIp.ToString()
+		};
+		if (preferredPort is > 0)
+		{
+			builder.Port = preferredPort.Value;
+		}
+		return builder.Uri;
+	}
+
+	private static IPAddress? TryGetPrivateIPv4()
+	{
+		try
+		{
+			foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+			{
+				if (nic.OperationalStatus != OperationalStatus.Up)
+				{
+					continue;
+				}
+
+				var props = nic.GetIPProperties();
+				foreach (var uni in props.UnicastAddresses)
+				{
+					var ip = uni.Address;
+					if (ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+					{
+						continue;
+					}
+					if (IPAddress.IsLoopback(ip))
+					{
+						continue;
+					}
+					if (!IsPrivateIPv4(ip))
+					{
+						continue;
+					}
+
+					return ip;
+				}
+			}
+		}
+		catch
+		{
+			// ignore
+		}
+
+		return null;
+	}
+
+	private static bool IsPrivateIPv4(IPAddress ip)
+	{
+		var b = ip.GetAddressBytes();
+		// 10.0.0.0/8
+		if (b[0] == 10) return true;
+		// 172.16.0.0/12
+		if (b[0] == 172 && b[1] >= 16 && b[1] <= 31) return true;
+		// 192.168.0.0/16
+		if (b[0] == 192 && b[1] == 168) return true;
+		return false;
+	}
+
+	private bool IsServerListeningOnNonLoopback()
+	{
+		var server = HttpContext.RequestServices.GetService<IServer>();
+		var addresses = server?.Features.Get<IServerAddressesFeature>()?.Addresses;
+		if (addresses is null || addresses.Count == 0)
+		{
+			// Unknown: don't block casting.
+			return true;
+		}
+
+		foreach (var address in addresses)
+		{
+			if (!Uri.TryCreate(address, UriKind.Absolute, out var uri))
+			{
+				continue;
+			}
+
+			// Kestrel uses these to mean "any".
+			if (string.Equals(uri.Host, "0.0.0.0", StringComparison.OrdinalIgnoreCase)
+				|| string.Equals(uri.Host, "[::]", StringComparison.OrdinalIgnoreCase)
+				|| string.Equals(uri.Host, "::", StringComparison.OrdinalIgnoreCase))
+			{
+				return true;
+			}
+
+			if (!IsLoopbackHost(uri.Host))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private string? GetServerUrlsHeaderValue()
+	{
+		var server = HttpContext.RequestServices.GetService<IServer>();
+		var addresses = server?.Features.Get<IServerAddressesFeature>()?.Addresses;
+		if (addresses is null || addresses.Count == 0)
+		{
+			return null;
+		}
+
+		// Avoid giant headers.
+		return string.Join(";", addresses.Take(10));
+	}
+
+	private static bool IsLoopbackHost(string host)
+	{
+		if (string.IsNullOrWhiteSpace(host))
+		{
+			return true;
+		}
+
+		if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
+		{
+			return true;
+		}
+
+		return System.Net.IPAddress.TryParse(host, out var ip) && System.Net.IPAddress.IsLoopback(ip);
+	}
+
+	private async Task<Uri?> ResolveJoinBaseUriAsync(CancellationToken cancellationToken)
+	{
+		var settings = await joinAddressSettings.GetAsync(cancellationToken).ConfigureAwait(false);
+		var lanHostPort = settings?.LanHostPort;
+		var wanHostPort = settings?.WanHostPort;
+
+		// Prefer explicit join-address settings (admin-configured) since Chromecast must reach the server.
+		if (!string.IsNullOrWhiteSpace(lanHostPort) || !string.IsNullOrWhiteSpace(wanHostPort))
+		{
+			var clientIp = HttpContext.Connection.RemoteIpAddress;
+			var mode = baseUrlOptions.Value.Mode;
+			var useLan = mode switch
+			{
+				BaseUrlMode.ForceLan => true,
+				BaseUrlMode.ForceWan => false,
+				BaseUrlMode.Auto => clientIp is not null && baseUrlResolver.IsLanClient(clientIp),
+				_ => false
+			};
+
+			var hostPort = useLan ? lanHostPort : wanHostPort;
+			if (string.IsNullOrWhiteSpace(hostPort))
+			{
+				hostPort = useLan ? wanHostPort : lanHostPort;
+			}
+
+			hostPort = (hostPort ?? string.Empty).Trim().TrimEnd('/');
+			if (string.IsNullOrWhiteSpace(hostPort))
+			{
+				return null;
+			}
+
+			var scheme = ResolveJoinScheme(hostPort, lanHostPort, wanHostPort, baseUrlOptions.Value, Request.Scheme);
+			return new Uri($"{scheme}://{hostPort}/", UriKind.Absolute);
+		}
+
+		// Fallback: use configured BaseUrl (appsettings/env). Helpful in dev.
+		try
+		{
+			var clientIp = HttpContext.Connection.RemoteIpAddress;
+			return baseUrlResolver.GetBaseUri(clientIp);
+		}
+		catch
+		{
+			// ignore; fall through
+		}
+
+		// Final fallback: use the current request host.
+		if (Request.Host.HasValue && (Request.Scheme is "http" or "https"))
+		{
+			return new Uri($"{Request.Scheme}://{Request.Host.Value}/", UriKind.Absolute);
+		}
+
+		return null;
+	}
+
+	private static string ResolveJoinScheme(
+		string hostPort,
+		string? lanHostPort,
+		string? wanHostPort,
+		BaseUrlOptions options,
+		string? requestScheme)
+	{
+		var normalizedHostPort = (hostPort ?? string.Empty).Trim();
+		var normalizedLan = (lanHostPort ?? string.Empty).Trim();
+		var normalizedWan = (wanHostPort ?? string.Empty).Trim();
+
+		string? preferredBase = null;
+		if (!string.IsNullOrWhiteSpace(normalizedLan)
+			&& string.Equals(normalizedHostPort, normalizedLan, StringComparison.OrdinalIgnoreCase))
+		{
+			preferredBase = options.Lan;
+		}
+		else if (!string.IsNullOrWhiteSpace(normalizedWan)
+			&& string.Equals(normalizedHostPort, normalizedWan, StringComparison.OrdinalIgnoreCase))
+		{
+			preferredBase = options.Wan;
+		}
+
+		if (!string.IsNullOrWhiteSpace(preferredBase)
+			&& Uri.TryCreate(preferredBase.Trim(), UriKind.Absolute, out var baseUri)
+			&& baseUri.Scheme is "http" or "https")
+		{
+			return baseUri.Scheme;
+		}
+
+		if (Uri.TryCreate("http://" + normalizedHostPort, UriKind.Absolute, out var parsed))
+		{
+			return parsed.Port == 443 ? "https" : "http";
+		}
+
+		if (string.Equals(requestScheme, "https", StringComparison.OrdinalIgnoreCase))
+		{
+			return "https";
+		}
+
+		return "http";
+	}
+
+	private static byte[] BuildQrPng(string text)
+	{
+		using var generator = new QRCodeGenerator();
+		using var data = generator.CreateQrCode(text, QRCodeGenerator.ECCLevel.Q);
+		var qr = new PngByteQRCode(data);
+		return qr.GetGraphic(pixelsPerModule: 10);
+	}
+}

--- a/src/Tindarr.Api/Controllers/PlaybackController.cs
+++ b/src/Tindarr.Api/Controllers/PlaybackController.cs
@@ -1,0 +1,116 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
+using Tindarr.Application.Abstractions.Security;
+using Tindarr.Application.Interfaces.Playback;
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Api.Controllers;
+
+[ApiController]
+[AllowAnonymous]
+[Route("api/v1/playback")]
+public sealed class PlaybackController(
+	IPlaybackTokenService playbackTokenService,
+	IEnumerable<IPlaybackProvider> providers,
+	IHttpClientFactory httpClientFactory,
+	ILogger<PlaybackController> logger) : ControllerBase
+{
+	[HttpGet("movie/{serviceType}/{serverId}/{tmdbId:int}")]
+	public async Task<IActionResult> StreamMovie(
+		[FromRoute] string serviceType,
+		[FromRoute] string serverId,
+		[FromRoute] int tmdbId,
+		[FromQuery] string? token,
+		CancellationToken cancellationToken)
+	{
+		if (tmdbId <= 0)
+		{
+			return BadRequest("Invalid TMDB id.");
+		}
+
+		if (!ServiceScope.TryCreate(serviceType, serverId, out var scope) || scope is null)
+		{
+			return BadRequest("Invalid service scope.");
+		}
+
+		token = string.IsNullOrWhiteSpace(token)
+			? Request.Headers["X-Tindarr-Playback-Token"].FirstOrDefault()
+			: token;
+
+		if (string.IsNullOrWhiteSpace(token) || !playbackTokenService.TryValidateMovieToken(token, scope, tmdbId, DateTimeOffset.UtcNow))
+		{
+			return Unauthorized();
+		}
+
+		var provider = providers.FirstOrDefault(p => p.ServiceType == scope.ServiceType);
+		if (provider is null)
+		{
+			return BadRequest("Unsupported playback provider.");
+		}
+
+		UpstreamPlaybackRequest upstream;
+		try
+		{
+			upstream = await provider.BuildMovieStreamRequestAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+		}
+		catch (InvalidOperationException ex)
+		{
+			logger.LogWarning(ex, "Failed to build upstream playback request. ServiceType={ServiceType} ServerId={ServerId} TmdbId={TmdbId}", scope.ServiceType, scope.ServerId, tmdbId);
+			return BadRequest(ex.Message);
+		}
+
+		logger.LogDebug("Proxying playback stream. ServiceType={ServiceType} ServerId={ServerId} TmdbId={TmdbId} UpstreamUri={UpstreamUri}", scope.ServiceType, scope.ServerId, tmdbId, upstream.Uri);
+
+		var client = httpClientFactory.CreateClient();
+		using var upstreamRequest = new HttpRequestMessage(HttpMethod.Get, upstream.Uri);
+		CopyRequestHeaderIfPresent(HeaderNames.Range);
+		CopyRequestHeaderIfPresent(HeaderNames.IfRange);
+		CopyRequestHeaderIfPresent(HeaderNames.IfModifiedSince);
+		CopyRequestHeaderIfPresent(HeaderNames.IfNoneMatch);
+		CopyRequestHeaderIfPresent(HeaderNames.Accept);
+
+		foreach (var header in upstream.Headers)
+		{
+			upstreamRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+		}
+
+		using HttpResponseMessage upstreamResponse = await client
+			.SendAsync(upstreamRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+			.ConfigureAwait(false);
+
+		logger.LogDebug("Upstream playback response. StatusCode={StatusCode} ContentType={ContentType}", (int)upstreamResponse.StatusCode, upstreamResponse.Content.Headers.ContentType?.ToString());
+
+		Response.StatusCode = (int)upstreamResponse.StatusCode;
+		CopyResponseHeaderIfPresent(HeaderNames.ContentType);
+		CopyResponseHeaderIfPresent(HeaderNames.ContentLength);
+		CopyResponseHeaderIfPresent(HeaderNames.AcceptRanges);
+		CopyResponseHeaderIfPresent(HeaderNames.ContentRange);
+		CopyResponseHeaderIfPresent(HeaderNames.ETag);
+		CopyResponseHeaderIfPresent(HeaderNames.LastModified);
+
+		// Some servers set Content-Disposition; ok for casting.
+		CopyResponseHeaderIfPresent(HeaderNames.ContentDisposition);
+
+		// Stream body
+		await upstreamResponse.Content.CopyToAsync(Response.Body, cancellationToken).ConfigureAwait(false);
+		return new EmptyResult();
+
+		void CopyRequestHeaderIfPresent(string headerName)
+		{
+			if (Request.Headers.TryGetValue(headerName, out var values))
+			{
+				upstreamRequest.Headers.TryAddWithoutValidation(headerName, (IEnumerable<string>)values);
+			}
+		}
+
+		void CopyResponseHeaderIfPresent(string headerName)
+		{
+			if (upstreamResponse.Headers.TryGetValues(headerName, out var values)
+				|| upstreamResponse.Content.Headers.TryGetValues(headerName, out values))
+			{
+				Response.Headers[headerName] = values.ToArray();
+			}
+		}
+	}
+}

--- a/src/Tindarr.Api/Controllers/PlexController.cs
+++ b/src/Tindarr.Api/Controllers/PlexController.cs
@@ -1,9 +1,17 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Tindarr.Api.Auth;
+using Tindarr.Api.Services;
+using Tindarr.Application.Abstractions.Caching;
+using Tindarr.Application.Abstractions.Integrations;
+using Tindarr.Application.Abstractions.Persistence;
 using Tindarr.Application.Interfaces.Integrations;
 using Tindarr.Application.Interfaces.Preferences;
+using Tindarr.Application.Options;
+using Tindarr.Contracts.Movies;
 using Tindarr.Contracts.Plex;
+using Tindarr.Contracts.Tmdb;
 using Tindarr.Domain.Common;
 
 namespace Tindarr.Api.Controllers;
@@ -13,6 +21,11 @@ namespace Tindarr.Api.Controllers;
 [Route("api/v1/plex")]
 public sealed class PlexController(
 	IPlexService plexService,
+	IPlexLibrarySyncJobService librarySyncJob,
+	IPlexLibraryCacheRepository plexLibraryCache,
+	ITmdbMetadataStore tmdbMetadataStore,
+	ITmdbImageCache imageCache,
+	IOptions<TmdbOptions> tmdbOptions,
 	IUserPreferencesService preferencesService) : ControllerBase
 {
 	[Authorize(Policy = Policies.AdminOnly)]
@@ -129,6 +142,61 @@ public sealed class PlexController(
 		}
 	}
 
+	[Authorize(Policy = Policies.AdminOnly)]
+	[HttpPost("library/sync/async")]
+	public async Task<ActionResult<PlexLibrarySyncStatusDto>> StartLibrarySync(
+		[FromQuery] string serviceType,
+		[FromQuery] string serverId,
+		CancellationToken cancellationToken)
+	{
+		if (!TryGetScope(serviceType, serverId, out var scope, out var errorResult))
+		{
+			return errorResult!;
+		}
+
+		var status = await librarySyncJob.StartAsync(scope!, cancellationToken);
+		return Accepted(new PlexLibrarySyncStatusDto(
+			ServiceType: status.ServiceType,
+			ServerId: status.ServerId,
+			State: status.State.ToString().ToLowerInvariant(),
+			TotalSections: status.TotalSections,
+			ProcessedSections: status.ProcessedSections,
+			TotalItems: status.TotalItems,
+			ProcessedItems: status.ProcessedItems,
+			TmdbIdsFound: status.TmdbIdsFound,
+			StartedAtUtc: status.StartedAtUtc,
+			FinishedAtUtc: status.FinishedAtUtc,
+			Message: status.Message,
+			UpdatedAtUtc: status.UpdatedAtUtc));
+	}
+
+	[Authorize(Policy = Policies.AdminOnly)]
+	[HttpGet("library/sync/status")]
+	public ActionResult<PlexLibrarySyncStatusDto> GetLibrarySyncStatus(
+		[FromQuery] string serviceType,
+		[FromQuery] string serverId)
+	{
+		if (!TryGetScope(serviceType, serverId, out var scope, out var errorResult))
+		{
+			return errorResult!;
+		}
+
+		var status = librarySyncJob.GetStatus(scope!);
+		return Ok(new PlexLibrarySyncStatusDto(
+			ServiceType: status.ServiceType,
+			ServerId: status.ServerId,
+			State: status.State.ToString().ToLowerInvariant(),
+			TotalSections: status.TotalSections,
+			ProcessedSections: status.ProcessedSections,
+			TotalItems: status.TotalItems,
+			ProcessedItems: status.ProcessedItems,
+			TmdbIdsFound: status.TmdbIdsFound,
+			StartedAtUtc: status.StartedAtUtc,
+			FinishedAtUtc: status.FinishedAtUtc,
+			Message: status.Message,
+			UpdatedAtUtc: status.UpdatedAtUtc));
+	}
+
 	[HttpGet("library")]
 	public async Task<ActionResult<PlexLibraryResponse>> GetLibrary(
 		[FromQuery] string serviceType,
@@ -165,6 +233,156 @@ public sealed class PlexController(
 		{
 			return StatusCode(StatusCodes.Status504GatewayTimeout, "Plex request timed out.");
 		}
+	}
+
+	[Authorize(Policy = Policies.AdminOnly)]
+	[HttpGet("library/missing-details")]
+	public async Task<ActionResult<PlexLibraryMissingDetailsResponse>> ListLibraryItemsMissingDetails(
+		[FromQuery] string serviceType,
+		[FromQuery] string serverId,
+		[FromQuery] int take = 100,
+		CancellationToken cancellationToken = default)
+	{
+		if (!TryGetScope(serviceType, serverId, out var scope, out var errorResult))
+		{
+			return errorResult!;
+		}
+
+		take = Math.Clamp(take, 1, 500);
+
+		var cached = await plexLibraryCache.ListItemsAsync(scope!, skip: 0, take: 2_000, cancellationToken).ConfigureAwait(false);
+		if (cached.Count == 0)
+		{
+			return Ok(new PlexLibraryMissingDetailsResponse(
+				ServiceType: scope!.ServiceType.ToString().ToLowerInvariant(),
+				ServerId: scope.ServerId,
+				Count: 0,
+				Items: Array.Empty<PlexLibraryMissingDetailsItemDto>()));
+		}
+
+		var missing = new List<PlexLibraryMissingDetailsItemDto>(capacity: Math.Min(take, cached.Count));
+		foreach (var item in cached)
+		{
+			var stored = await tmdbMetadataStore.GetMovieAsync(item.TmdbId, cancellationToken).ConfigureAwait(false);
+			var hasDetails = stored?.DetailsFetchedAtUtc is not null;
+			if (hasDetails)
+			{
+				continue;
+			}
+
+			missing.Add(new PlexLibraryMissingDetailsItemDto(item.TmdbId, item.Title));
+			if (missing.Count >= take)
+			{
+				break;
+			}
+		}
+
+		return Ok(new PlexLibraryMissingDetailsResponse(
+			ServiceType: scope!.ServiceType.ToString().ToLowerInvariant(),
+			ServerId: scope.ServerId,
+			Count: missing.Count,
+			Items: missing));
+	}
+
+	[Authorize(Policy = Policies.AdminOnly)]
+	[HttpGet("library/cache/movies")]
+	public async Task<ActionResult<TmdbStoredMovieAdminListResponse>> ListLibraryCacheMovies(
+		[FromQuery] string serviceType,
+		[FromQuery] string serverId,
+		[FromQuery] int skip = 0,
+		[FromQuery] int take = 50,
+		[FromQuery] bool missingDetailsOnly = false,
+		[FromQuery] bool missingImagesOnly = false,
+		CancellationToken cancellationToken = default)
+	{
+		if (!TryGetScope(serviceType, serverId, out var scope, out var errorResult))
+		{
+			return errorResult!;
+		}
+
+		skip = Math.Max(0, skip);
+		take = Math.Clamp(take, 1, 200);
+
+		var settings = await tmdbMetadataStore.GetSettingsAsync(cancellationToken).ConfigureAwait(false);
+		var canCheckImages = settings.PosterMode == TmdbPosterMode.LocalProxy && settings.ImageCacheMaxMb > 0;
+		var posterSize = tmdbOptions.Value.PosterSize;
+		var backdropSize = tmdbOptions.Value.BackdropSize;
+
+		var items = new List<TmdbStoredMovieAdminDto>(capacity: take);
+		var nextSkip = skip;
+		var hasMore = false;
+
+		// Like TMDB cache listing: if missingImagesOnly is requested, scan forward to fill the page.
+		for (var iter = 0; iter < 10 && items.Count < take; iter++)
+		{
+			var cacheChunk = await plexLibraryCache.ListItemsAsync(scope!, nextSkip, take, cancellationToken).ConfigureAwait(false);
+			if (cacheChunk.Count == 0)
+			{
+				hasMore = false;
+				break;
+			}
+
+			nextSkip += cacheChunk.Count;
+			hasMore = cacheChunk.Count == take;
+
+			foreach (var entry in cacheChunk)
+			{
+				var stored = await tmdbMetadataStore.GetMovieAsync(entry.TmdbId, cancellationToken).ConfigureAwait(false);
+				var title = stored?.Title ?? entry.Title;
+				var hasDetails = stored?.DetailsFetchedAtUtc is not null;
+				if (missingDetailsOnly && hasDetails)
+				{
+					continue;
+				}
+
+				var posterCached = false;
+				var backdropCached = false;
+				if (canCheckImages)
+				{
+					if (!string.IsNullOrWhiteSpace(stored?.PosterPath))
+					{
+						posterCached = await imageCache.HasAsync(posterSize, stored!.PosterPath!, cancellationToken).ConfigureAwait(false);
+					}
+					if (!string.IsNullOrWhiteSpace(stored?.BackdropPath))
+					{
+						backdropCached = await imageCache.HasAsync(backdropSize, stored!.BackdropPath!, cancellationToken).ConfigureAwait(false);
+					}
+				}
+
+				if (missingImagesOnly)
+				{
+					var posterMissing = !string.IsNullOrWhiteSpace(stored?.PosterPath) && !posterCached;
+					var backdropMissing = !string.IsNullOrWhiteSpace(stored?.BackdropPath) && !backdropCached;
+					if (!posterMissing && !backdropMissing)
+					{
+						continue;
+					}
+				}
+
+				items.Add(new TmdbStoredMovieAdminDto(
+					TmdbId: entry.TmdbId,
+					Title: title,
+					ReleaseYear: stored?.ReleaseYear,
+					PosterPath: stored?.PosterPath,
+					BackdropPath: stored?.BackdropPath,
+					DetailsFetchedAtUtc: stored?.DetailsFetchedAtUtc,
+					UpdatedAtUtc: stored?.UpdatedAtUtc,
+					PosterCached: posterCached,
+					BackdropCached: backdropCached));
+
+				if (items.Count >= take)
+				{
+					break;
+				}
+			}
+		}
+
+		return Ok(new TmdbStoredMovieAdminListResponse(
+			Items: items,
+			Skip: skip,
+			Take: take,
+			NextSkip: nextSkip,
+			HasMore: hasMore));
 	}
 
 	private static bool TryGetScope(

--- a/src/Tindarr.Api/Services/PlexLibrarySyncJobService.cs
+++ b/src/Tindarr.Api/Services/PlexLibrarySyncJobService.cs
@@ -1,0 +1,144 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Tindarr.Application.Interfaces.Integrations;
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Api.Services;
+
+public enum PlexLibrarySyncJobState
+{
+	Idle = 0,
+	Running = 1,
+	Completed = 2,
+	Failed = 3
+}
+
+public sealed record PlexLibrarySyncJobStatus(
+	string ServiceType,
+	string ServerId,
+	PlexLibrarySyncJobState State,
+	int TotalSections,
+	int ProcessedSections,
+	int TotalItems,
+	int ProcessedItems,
+	int TmdbIdsFound,
+	DateTimeOffset? StartedAtUtc,
+	DateTimeOffset? FinishedAtUtc,
+	string? Message,
+	DateTimeOffset UpdatedAtUtc);
+
+public interface IPlexLibrarySyncJobService
+{
+	PlexLibrarySyncJobStatus GetStatus(ServiceScope scope);
+	Task<PlexLibrarySyncJobStatus> StartAsync(ServiceScope scope, CancellationToken cancellationToken);
+}
+
+public sealed class PlexLibrarySyncJobService(IServiceScopeFactory scopeFactory) : IPlexLibrarySyncJobService
+{
+	private sealed class JobEntry
+	{
+		public readonly SemaphoreSlim Gate = new(1, 1);
+		public PlexLibrarySyncJobStatus Status = new(
+			ServiceType: "plex",
+			ServerId: "default",
+			State: PlexLibrarySyncJobState.Idle,
+			TotalSections: 0,
+			ProcessedSections: 0,
+			TotalItems: 0,
+			ProcessedItems: 0,
+			TmdbIdsFound: 0,
+			StartedAtUtc: null,
+			FinishedAtUtc: null,
+			Message: null,
+			UpdatedAtUtc: DateTimeOffset.UtcNow);
+	}
+
+	private readonly ConcurrentDictionary<string, JobEntry> _jobs = new(StringComparer.OrdinalIgnoreCase);
+
+	private static string Key(ServiceScope scope) => $"{scope.ServiceType}:{scope.ServerId}";
+
+	public PlexLibrarySyncJobStatus GetStatus(ServiceScope scope)
+	{
+		var entry = _jobs.GetOrAdd(Key(scope), _ => new JobEntry());
+		return entry.Status;
+	}
+
+	public async Task<PlexLibrarySyncJobStatus> StartAsync(ServiceScope scope, CancellationToken cancellationToken)
+	{
+		var entry = _jobs.GetOrAdd(Key(scope), _ => new JobEntry());
+		await entry.Gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+		try
+		{
+			if (entry.Status.State == PlexLibrarySyncJobState.Running)
+			{
+				return entry.Status;
+			}
+
+			var startedAt = DateTimeOffset.UtcNow;
+			entry.Status = entry.Status with
+			{
+				ServiceType = scope.ServiceType.ToString().ToLowerInvariant(),
+				ServerId = scope.ServerId,
+				State = PlexLibrarySyncJobState.Running,
+				TotalSections = 0,
+				ProcessedSections = 0,
+				TotalItems = 0,
+				ProcessedItems = 0,
+				TmdbIdsFound = 0,
+				StartedAtUtc = startedAt,
+				FinishedAtUtc = null,
+				Message = null,
+				UpdatedAtUtc = startedAt
+			};
+
+			_ = Task.Run(async () =>
+			{
+				var progress = new Progress<PlexLibrarySyncProgress>(p =>
+				{
+					entry.Status = entry.Status with
+					{
+						TotalSections = p.TotalSections,
+						ProcessedSections = p.ProcessedSections,
+						TotalItems = p.TotalItems,
+						ProcessedItems = p.ProcessedItems,
+						TmdbIdsFound = p.TmdbIdsFound,
+						Message = string.IsNullOrWhiteSpace(p.CurrentSectionTitle) ? "Syncing…" : $"Syncing: {p.CurrentSectionTitle}",
+						UpdatedAtUtc = DateTimeOffset.UtcNow
+					};
+				});
+
+				try
+				{
+					using var serviceScope = scopeFactory.CreateScope();
+					var plexService = serviceScope.ServiceProvider.GetRequiredService<IPlexService>();
+					await plexService.SyncLibraryWithProgressAsync(scope, progress, CancellationToken.None).ConfigureAwait(false);
+					var finishedAt = DateTimeOffset.UtcNow;
+					entry.Status = entry.Status with
+					{
+						State = PlexLibrarySyncJobState.Completed,
+						FinishedAtUtc = finishedAt,
+						Message = "Sync complete.",
+						UpdatedAtUtc = finishedAt
+					};
+				}
+				catch (Exception ex)
+				{
+					var finishedAt = DateTimeOffset.UtcNow;
+					entry.Status = entry.Status with
+					{
+						State = PlexLibrarySyncJobState.Failed,
+						FinishedAtUtc = finishedAt,
+						Message = ex.Message,
+						UpdatedAtUtc = finishedAt
+					};
+				}
+			});
+
+			return entry.Status;
+		}
+		finally
+		{
+			entry.Gate.Release();
+		}
+	}
+}

--- a/src/Tindarr.Api/Tindarr.Api.csproj
+++ b/src/Tindarr.Api/Tindarr.Api.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+	<SpaDistDir>..\..\ui\dist\</SpaDistDir>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,5 +20,18 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
+    <PackageReference Include="QRCoder" Version="1.6.0" />
   </ItemGroup>
+
+	<Target Name="CopySpaDistToWwwroot" AfterTargets="Build">
+		<ItemGroup Condition="Exists('$(SpaDistDir)')">
+			<SpaDistFiles Include="$(SpaDistDir)**\*.*" />
+		</ItemGroup>
+
+		<Copy
+			SourceFiles="@(SpaDistFiles)"
+			DestinationFiles="@(SpaDistFiles->'$(MSBuildProjectDirectory)\wwwroot\%(RecursiveDir)%(Filename)%(Extension)')"
+			SkipUnchangedFiles="true"
+			Condition="@(SpaDistFiles) != ''" />
+	</Target>
 </Project>

--- a/src/Tindarr.Application/Abstractions/Integrations/ITmdbMetadataStore.cs
+++ b/src/Tindarr.Application/Abstractions/Integrations/ITmdbMetadataStore.cs
@@ -19,9 +19,18 @@ public sealed record TmdbMetadataStats(int MovieCount, long ImageCacheBytes);
 public sealed record TmdbStoredMovie(
 	int TmdbId,
 	string Title,
+	string? Overview,
+	string? ReleaseDate,
 	int? ReleaseYear,
 	string? PosterPath,
 	string? BackdropPath,
+	string? MpaaRating,
+	double? Rating,
+	int? VoteCount,
+	IReadOnlyList<string> Genres,
+	IReadOnlyList<string> Regions,
+	string? OriginalLanguage,
+	int? RuntimeMinutes,
 	DateTimeOffset? DetailsFetchedAtUtc,
 	DateTimeOffset? UpdatedAtUtc);
 
@@ -32,6 +41,8 @@ public interface ITmdbMetadataStore
 	ValueTask<TmdbMetadataSettings> SetSettingsAsync(TmdbMetadataSettings settings, CancellationToken cancellationToken);
 
 	ValueTask<TmdbMetadataStats> GetStatsAsync(CancellationToken cancellationToken);
+
+	Task UpsertMoviesAsync(IReadOnlyList<TmdbDiscoverMovieRecord> movies, CancellationToken cancellationToken);
 
 	Task AddToUserPoolAsync(string userId, IReadOnlyList<TmdbDiscoverMovieRecord> discovered, CancellationToken cancellationToken);
 

--- a/src/Tindarr.Application/Abstractions/Persistence/IPlexDeckIndexRepository.cs
+++ b/src/Tindarr.Application/Abstractions/Persistence/IPlexDeckIndexRepository.cs
@@ -1,0 +1,12 @@
+using Tindarr.Contracts.Movies;
+using Tindarr.Domain.Common;
+using Tindarr.Domain.Interactions;
+
+namespace Tindarr.Application.Abstractions.Persistence;
+
+public interface IPlexDeckIndexRepository
+{
+	Task UpsertAsync(ServiceScope scope, IReadOnlyCollection<MovieDetailsDto> details, DateTimeOffset updatedAtUtc, CancellationToken cancellationToken);
+
+	Task<IReadOnlyList<SwipeCard>> QueryAsync(ServiceScope scope, UserPreferencesRecord preferences, int limit, CancellationToken cancellationToken);
+}

--- a/src/Tindarr.Application/Abstractions/Persistence/IPlexLibraryCacheRepository.cs
+++ b/src/Tindarr.Application/Abstractions/Persistence/IPlexLibraryCacheRepository.cs
@@ -1,4 +1,5 @@
 using Tindarr.Domain.Common;
+using Tindarr.Application.Abstractions.Integrations;
 
 namespace Tindarr.Application.Abstractions.Persistence;
 
@@ -6,7 +7,13 @@ public interface IPlexLibraryCacheRepository
 {
 	Task<IReadOnlyCollection<int>> GetTmdbIdsAsync(ServiceScope scope, CancellationToken cancellationToken);
 
+	Task<IReadOnlyList<PlexLibraryItem>> ListItemsAsync(ServiceScope scope, int skip, int take, CancellationToken cancellationToken);
+
+	Task<string?> TryGetRatingKeyAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken);
+
 	Task ReplaceTmdbIdsAsync(ServiceScope scope, IReadOnlyCollection<int> tmdbIds, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken);
+
+	Task ReplaceItemsAsync(ServiceScope scope, IReadOnlyCollection<PlexLibraryItem> items, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken);
 
 	Task AddTmdbIdsAsync(ServiceScope scope, IReadOnlyCollection<int> tmdbIds, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken);
 

--- a/src/Tindarr.Application/Abstractions/Security/ICastUrlTokenService.cs
+++ b/src/Tindarr.Application/Abstractions/Security/ICastUrlTokenService.cs
@@ -1,0 +1,8 @@
+namespace Tindarr.Application.Abstractions.Security;
+
+public interface ICastUrlTokenService
+{
+	string IssueRoomQrToken(string roomId, DateTimeOffset nowUtc);
+
+	bool TryValidateRoomQrToken(string token, string roomId, DateTimeOffset nowUtc);
+}

--- a/src/Tindarr.Application/Abstractions/Security/IPlaybackTokenService.cs
+++ b/src/Tindarr.Application/Abstractions/Security/IPlaybackTokenService.cs
@@ -1,0 +1,10 @@
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Application.Abstractions.Security;
+
+public interface IPlaybackTokenService
+{
+	string IssueMovieToken(ServiceScope scope, int tmdbId, DateTimeOffset nowUtc);
+
+	bool TryValidateMovieToken(string token, ServiceScope scope, int tmdbId, DateTimeOffset nowUtc);
+}

--- a/src/Tindarr.Application/Interfaces/Casting/ICastClient.cs
+++ b/src/Tindarr.Application/Interfaces/Casting/ICastClient.cs
@@ -1,0 +1,20 @@
+namespace Tindarr.Application.Interfaces.Casting;
+
+public interface ICastClient
+{
+	Task<IReadOnlyList<CastDevice>> DiscoverAsync(CancellationToken cancellationToken);
+
+	Task CastAsync(string deviceId, CastMedia media, CancellationToken cancellationToken);
+}
+
+public sealed record CastDevice(
+	string Id,
+	string Name,
+	string? Address,
+	int Port);
+
+public sealed record CastMedia(
+	string ContentUrl,
+	string ContentType,
+	string? Title,
+	string? SubTitle);

--- a/src/Tindarr.Application/Interfaces/Integrations/IPlexService.cs
+++ b/src/Tindarr.Application/Interfaces/Integrations/IPlexService.cs
@@ -18,6 +18,11 @@ public interface IPlexService
 
 	Task<PlexLibrarySyncResult> SyncLibraryAsync(ServiceScope scope, CancellationToken cancellationToken);
 
+	Task<PlexLibrarySyncResult> SyncLibraryWithProgressAsync(
+		ServiceScope scope,
+		IProgress<PlexLibrarySyncProgress> progress,
+		CancellationToken cancellationToken);
+
 	Task<PlexLibrarySyncResult?> EnsureLibrarySyncAsync(ServiceScope scope, CancellationToken cancellationToken);
 
 	Task<IReadOnlyList<MovieDetailsDto>> GetLibraryAsync(
@@ -32,6 +37,14 @@ public interface IPlexService
 		int limit,
 		CancellationToken cancellationToken);
 }
+
+public sealed record PlexLibrarySyncProgress(
+	int TotalSections,
+	int ProcessedSections,
+	int TotalItems,
+	int ProcessedItems,
+	int TmdbIdsFound,
+	string? CurrentSectionTitle);
 
 public sealed record PlexPinCreateResult(
 	long PinId,

--- a/src/Tindarr.Application/Interfaces/Playback/IPlaybackProvider.cs
+++ b/src/Tindarr.Application/Interfaces/Playback/IPlaybackProvider.cs
@@ -1,0 +1,18 @@
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Application.Interfaces.Playback;
+
+public interface IPlaybackProvider
+{
+	ServiceType ServiceType { get; }
+
+	/// <summary>
+	/// Builds the upstream request for a movie stream.
+	/// The returned request MUST contain provider credentials as headers (never in the returned URL).
+	/// </summary>
+	Task<UpstreamPlaybackRequest> BuildMovieStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken);
+}
+
+public sealed record UpstreamPlaybackRequest(
+	Uri Uri,
+	IReadOnlyDictionary<string, string> Headers);

--- a/src/Tindarr.Application/Options/PlaybackOptions.cs
+++ b/src/Tindarr.Application/Options/PlaybackOptions.cs
@@ -1,0 +1,17 @@
+namespace Tindarr.Application.Options;
+
+public sealed class PlaybackOptions
+{
+	public const string SectionName = "Playback";
+
+	/// <summary>
+	/// How long a playback token is valid for.
+	/// Cast devices cannot send auth headers, so the token is embedded in the URL.
+	/// </summary>
+	public int TokenMinutes { get; init; } = 10;
+
+	public bool IsValid()
+	{
+		return TokenMinutes is >= 1 and <= 60;
+	}
+}

--- a/src/Tindarr.Contracts/Casting/CastDeviceDto.cs
+++ b/src/Tindarr.Contracts/Casting/CastDeviceDto.cs
@@ -1,0 +1,7 @@
+namespace Tindarr.Contracts.Casting;
+
+public sealed record CastDeviceDto(
+	string Id,
+	string Name,
+	string? Address,
+	int Port);

--- a/src/Tindarr.Contracts/Casting/CastMovieRequest.cs
+++ b/src/Tindarr.Contracts/Casting/CastMovieRequest.cs
@@ -1,0 +1,8 @@
+namespace Tindarr.Contracts.Casting;
+
+public sealed record CastMovieRequest(
+	string DeviceId,
+	string ServiceType,
+	string ServerId,
+	int TmdbId,
+	string? Title);

--- a/src/Tindarr.Contracts/Casting/CastQrRequest.cs
+++ b/src/Tindarr.Contracts/Casting/CastQrRequest.cs
@@ -1,0 +1,3 @@
+namespace Tindarr.Contracts.Casting;
+
+public sealed record CastQrRequest(string DeviceId);

--- a/src/Tindarr.Contracts/Plex/PlexLibraryMissingDetailsItemDto.cs
+++ b/src/Tindarr.Contracts/Plex/PlexLibraryMissingDetailsItemDto.cs
@@ -1,0 +1,5 @@
+namespace Tindarr.Contracts.Plex;
+
+public sealed record PlexLibraryMissingDetailsItemDto(
+	int TmdbId,
+	string Title);

--- a/src/Tindarr.Contracts/Plex/PlexLibraryMissingDetailsResponse.cs
+++ b/src/Tindarr.Contracts/Plex/PlexLibraryMissingDetailsResponse.cs
@@ -1,0 +1,7 @@
+namespace Tindarr.Contracts.Plex;
+
+public sealed record PlexLibraryMissingDetailsResponse(
+	string ServiceType,
+	string ServerId,
+	int Count,
+	IReadOnlyList<PlexLibraryMissingDetailsItemDto> Items);

--- a/src/Tindarr.Contracts/Plex/PlexLibrarySyncStatusDto.cs
+++ b/src/Tindarr.Contracts/Plex/PlexLibrarySyncStatusDto.cs
@@ -1,0 +1,15 @@
+namespace Tindarr.Contracts.Plex;
+
+public sealed record PlexLibrarySyncStatusDto(
+	string ServiceType,
+	string ServerId,
+	string State,
+	int TotalSections,
+	int ProcessedSections,
+	int TotalItems,
+	int ProcessedItems,
+	int TmdbIdsFound,
+	DateTimeOffset? StartedAtUtc,
+	DateTimeOffset? FinishedAtUtc,
+	string? Message,
+	DateTimeOffset UpdatedAtUtc);

--- a/src/Tindarr.Infrastructure/Casting/SharpCasterCastClient.cs
+++ b/src/Tindarr.Infrastructure/Casting/SharpCasterCastClient.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.Logging;
+using Sharpcaster;
+using Sharpcaster.Models;
+using Sharpcaster.Models.Media;
+using Tindarr.Application.Interfaces.Casting;
+
+namespace Tindarr.Infrastructure.Casting;
+
+public sealed class SharpCasterCastClient(ILoggerFactory loggerFactory, ILogger<SharpCasterCastClient> logger) : ICastClient
+{
+	private const string DefaultMediaReceiverAppId = "CC1AD845";
+
+	public async Task<IReadOnlyList<CastDevice>> DiscoverAsync(CancellationToken cancellationToken)
+	{
+		var locator = new ChromecastLocator();
+		var receivers = await locator.FindReceiversAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+
+		return receivers
+			.OrderBy(r => r.Name)
+			.Select(r => new CastDevice(
+				Id: ToDeviceId(r),
+				Name: (r.Name ?? string.Empty).Trim(),
+				Address: r.DeviceUri?.Host,
+				Port: r.Port))
+			.Where(d => !string.IsNullOrWhiteSpace(d.Id) && !string.IsNullOrWhiteSpace(d.Name))
+			.ToList();
+	}
+
+	public async Task CastAsync(string deviceId, CastMedia media, CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(deviceId))
+		{
+			throw new ArgumentException("deviceId is required", nameof(deviceId));
+		}
+		if (string.IsNullOrWhiteSpace(media.ContentUrl))
+		{
+			throw new ArgumentException("ContentUrl is required", nameof(media));
+		}
+		if (string.IsNullOrWhiteSpace(media.ContentType))
+		{
+			throw new ArgumentException("ContentType is required", nameof(media));
+		}
+
+		var locator = new ChromecastLocator();
+		var receivers = await locator.FindReceiversAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+		var receiver = receivers.FirstOrDefault(r => string.Equals(ToDeviceId(r), deviceId, StringComparison.Ordinal));
+		if (receiver is null)
+		{
+			throw new InvalidOperationException("Cast device not found.");
+		}
+
+		var clientLogger = loggerFactory.CreateLogger<ChromecastClient>();
+		var client = new ChromecastClient(clientLogger);
+		try
+		{
+			await client.ConnectChromecast(receiver).ConfigureAwait(false);
+			await client.LaunchApplicationAsync(DefaultMediaReceiverAppId).ConfigureAwait(false);
+
+			var m = new Media
+			{
+				ContentUrl = media.ContentUrl,
+				ContentType = media.ContentType,
+				Metadata = new MediaMetadata
+				{
+					Title = media.Title,
+					SubTitle = media.SubTitle
+				}
+			};
+
+			await client.MediaChannel.LoadAsync(m).ConfigureAwait(false);
+		}
+		catch (Exception ex)
+		{
+			logger.LogWarning(ex, "cast failed. DeviceId={DeviceId} Url={Url}", deviceId, media.ContentUrl);
+			throw;
+		}
+		finally
+		{
+			try
+			{
+				await client.Dispose().ConfigureAwait(false);
+			}
+			catch
+			{
+				// ignore
+			}
+		}
+	}
+
+	private static string ToDeviceId(ChromecastReceiver receiver)
+	{
+		var host = receiver.DeviceUri?.Host;
+		if (string.IsNullOrWhiteSpace(host))
+		{
+			return string.Empty;
+		}
+		return $"{host}:{receiver.Port}";
+	}
+}

--- a/src/Tindarr.Infrastructure/Integrations/Plex/PlexSwipeDeckSource.cs
+++ b/src/Tindarr.Infrastructure/Integrations/Plex/PlexSwipeDeckSource.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using Microsoft.Extensions.Logging;
+using Tindarr.Application.Abstractions.Persistence;
 using Tindarr.Application.Interfaces.Integrations;
 using Tindarr.Application.Interfaces.Interactions;
 using Tindarr.Application.Interfaces.Preferences;
@@ -10,6 +11,9 @@ namespace Tindarr.Infrastructure.Integrations.Plex;
 
 public sealed class PlexSwipeDeckSource(
 	IPlexService plexService,
+	IPlexDeckIndexRepository deckIndex,
+	IServiceSettingsRepository settingsRepo,
+	IPlexLibraryCacheRepository plexLibraryCache,
 	IUserPreferencesService preferencesService,
 	ILogger<PlexSwipeDeckSource> logger) : ISwipeDeckSource
 {
@@ -19,7 +23,46 @@ public sealed class PlexSwipeDeckSource(
 
 		try
 		{
+			// Fast path: query the precomputed deck index in plexcache.db.
+			var indexed = await deckIndex.QueryAsync(scope, prefs, limit: 250, cancellationToken).ConfigureAwait(false);
+			if (indexed.Count > 0)
+			{
+				return indexed;
+			}
+
+			// Fallback path: on-demand TMDB lookups through PlexService.
 			var library = await plexService.GetCachedLibraryAsync(scope, prefs, limit: 200, cancellationToken).ConfigureAwait(false);
+			if (library.Count == 0)
+			{
+				// Plex swipedeck relies on a cached library sync; if this is a fresh install, kick off a sync once.
+				await plexService.EnsureLibrarySyncAsync(scope, cancellationToken).ConfigureAwait(false);
+				library = await plexService.GetCachedLibraryAsync(scope, prefs, limit: 200, cancellationToken).ConfigureAwait(false);
+				if (library.Count == 0)
+				{
+					var cachedIds = await plexLibraryCache.GetTmdbIdsAsync(scope, cancellationToken).ConfigureAwait(false);
+					var settings = await settingsRepo.GetAsync(scope, cancellationToken).ConfigureAwait(false);
+					var lastSync = settings?.PlexLastLibrarySyncUtc;
+
+					if (cachedIds.Count == 0)
+					{
+						if (lastSync is not null)
+						{
+							throw new InvalidOperationException(
+								$"Plex library sync ran at {lastSync:O}, but no TMDB IDs were cached for this server. " +
+								"This usually means Plex did not provide TMDB GUIDs for your movies. " +
+								"In Plex, refresh metadata / ensure your agent includes TMDB IDs, then sync again in Admin Console → Plex.");
+						}
+
+						throw new InvalidOperationException(
+							"Plex library is not synced yet. Sync the Plex library in Admin Console, then try again.");
+					}
+
+					throw new InvalidOperationException(
+						$"Plex library has {cachedIds.Count} cached TMDB IDs, but no swipe cards could be built yet. " +
+						"Fetch details in Admin Console → Plex → Cache contents → Fetch all details, then try again.");
+				}
+			}
+
 			return library
 				.Select(m => new SwipeCard(
 					TmdbId: m.TmdbId,

--- a/src/Tindarr.Infrastructure/Playback/Providers/EmbyPlaybackProvider.cs
+++ b/src/Tindarr.Infrastructure/Playback/Providers/EmbyPlaybackProvider.cs
@@ -1,0 +1,144 @@
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Tindarr.Application.Abstractions.Persistence;
+using Tindarr.Application.Interfaces.Playback;
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Infrastructure.Playback.Providers;
+
+public sealed class EmbyPlaybackProvider(
+	IServiceSettingsRepository settingsRepo,
+	HttpClient httpClient,
+	ILogger<EmbyPlaybackProvider> logger) : IPlaybackProvider
+{
+	private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+	public ServiceType ServiceType => ServiceType.Emby;
+
+	public async Task<UpstreamPlaybackRequest> BuildMovieStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
+	{
+		var settings = await settingsRepo.GetAsync(scope, cancellationToken).ConfigureAwait(false);
+		if (settings is null || string.IsNullOrWhiteSpace(settings.EmbyBaseUrl) || string.IsNullOrWhiteSpace(settings.EmbyApiKey))
+		{
+			throw new InvalidOperationException("Emby server is not configured.");
+		}
+
+		var baseUrl = NormalizeEmbyBaseUrl(settings.EmbyBaseUrl);
+		var apiKey = settings.EmbyApiKey!;
+
+		var userId = await ResolveAdminUserIdAsync(httpClient, baseUrl, apiKey, cancellationToken).ConfigureAwait(false);
+		if (string.IsNullOrWhiteSpace(userId))
+		{
+			throw new InvalidOperationException("Emby did not return any users.");
+		}
+
+		var itemId = await FindMovieItemIdAsync(httpClient, baseUrl, apiKey, userId, tmdbId, cancellationToken).ConfigureAwait(false);
+		if (string.IsNullOrWhiteSpace(itemId))
+		{
+			throw new InvalidOperationException("Emby item not found.");
+		}
+
+		var upstreamUri = new Uri($"{baseUrl}Videos/{Uri.EscapeDataString(itemId)}/stream?static=true", UriKind.Absolute);
+		return new UpstreamPlaybackRequest(
+			Uri: upstreamUri,
+			Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+			{
+				["X-Emby-Token"] = apiKey
+			});
+	}
+
+	private static async Task<string?> ResolveAdminUserIdAsync(HttpClient client, string baseUrl, string apiKey, CancellationToken cancellationToken)
+	{
+		var uri = new Uri($"{baseUrl}Users", UriKind.Absolute);
+		using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+		request.Headers.Accept.ParseAdd("application/json");
+		request.Headers.Add("X-Emby-Token", apiKey);
+
+		using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+		response.EnsureSuccessStatusCode();
+		var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+		var users = JsonSerializer.Deserialize<List<UserDto>>(json, Json) ?? [];
+		if (users.Count == 0)
+		{
+			return null;
+		}
+
+		var admin = users.FirstOrDefault(u => u.Policy?.IsAdministrator == true);
+		return (admin ?? users[0]).Id?.Trim();
+	}
+
+	private async Task<string?> FindMovieItemIdAsync(
+		HttpClient client,
+		string baseUrl,
+		string apiKey,
+		string userId,
+		int tmdbId,
+		CancellationToken cancellationToken)
+	{
+		var candidates = new[]
+		{
+			$"Users/{Uri.EscapeDataString(userId)}/Items?IncludeItemTypes=Movie&Recursive=true&Limit=1&Fields=ProviderIds&AnyProviderIdEquals=tmdb.{tmdbId}",
+			$"Users/{Uri.EscapeDataString(userId)}/Items?IncludeItemTypes=Movie&Recursive=true&Limit=1&Fields=ProviderIds&AnyProviderIdEquals=Tmdb.{tmdbId}",
+		};
+
+		foreach (var query in candidates)
+		{
+			var uri = new Uri($"{baseUrl}{query}", UriKind.Absolute);
+			using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+			request.Headers.Accept.ParseAdd("application/json");
+			request.Headers.Add("X-Emby-Token", apiKey);
+			using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+			if (!response.IsSuccessStatusCode)
+			{
+				continue;
+			}
+
+			var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+			var dto = JsonSerializer.Deserialize<ItemsResponseDto>(json, Json);
+			var id = dto?.Items?.FirstOrDefault()?.Id;
+			if (!string.IsNullOrWhiteSpace(id))
+			{
+				return id.Trim();
+			}
+		}
+
+		logger.LogDebug("emby item id lookup failed. TmdbId={TmdbId}", tmdbId);
+		return null;
+	}
+
+	private static string NormalizeEmbyBaseUrl(string baseUrl)
+	{
+		var trimmed = (baseUrl ?? string.Empty).Trim().TrimEnd('/');
+		if (string.IsNullOrWhiteSpace(trimmed))
+		{
+			return string.Empty;
+		}
+
+		// Emby API is under /emby/ unless user already configured it.
+		if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+		{
+			var absolutePath = (uri.AbsolutePath ?? string.Empty).TrimEnd('/');
+			var endsWithEmby = absolutePath.EndsWith("/emby", StringComparison.OrdinalIgnoreCase)
+				|| string.Equals(absolutePath, "emby", StringComparison.OrdinalIgnoreCase);
+			return endsWithEmby ? trimmed + "/" : trimmed + "/emby/";
+		}
+
+		return trimmed.EndsWith("/emby", StringComparison.OrdinalIgnoreCase)
+			? trimmed + "/"
+			: trimmed + "/emby/";
+	}
+
+	private sealed record UserDto(
+		[property: JsonPropertyName("Id")] string? Id,
+		[property: JsonPropertyName("Policy")] UserPolicyDto? Policy);
+
+	private sealed record UserPolicyDto([property: JsonPropertyName("IsAdministrator")] bool IsAdministrator);
+
+	private sealed record ItemsResponseDto(
+		[property: JsonPropertyName("Items")] List<ItemDto>? Items,
+		[property: JsonPropertyName("TotalRecordCount")] int TotalRecordCount);
+
+	private sealed record ItemDto([property: JsonPropertyName("Id")] string? Id);
+}

--- a/src/Tindarr.Infrastructure/Playback/Providers/JellyfinPlaybackProvider.cs
+++ b/src/Tindarr.Infrastructure/Playback/Providers/JellyfinPlaybackProvider.cs
@@ -1,0 +1,131 @@
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Tindarr.Application.Abstractions.Persistence;
+using Tindarr.Application.Interfaces.Playback;
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Infrastructure.Playback.Providers;
+
+public sealed class JellyfinPlaybackProvider(
+	IServiceSettingsRepository settingsRepo,
+	HttpClient httpClient,
+	ILogger<JellyfinPlaybackProvider> logger) : IPlaybackProvider
+{
+	private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+	public ServiceType ServiceType => ServiceType.Jellyfin;
+
+	public async Task<UpstreamPlaybackRequest> BuildMovieStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
+	{
+		var settings = await settingsRepo.GetAsync(scope, cancellationToken).ConfigureAwait(false);
+		if (settings is null || string.IsNullOrWhiteSpace(settings.JellyfinBaseUrl) || string.IsNullOrWhiteSpace(settings.JellyfinApiKey))
+		{
+			throw new InvalidOperationException("Jellyfin server is not configured.");
+		}
+
+		var baseUrl = NormalizeJellyfinBaseUrl(settings.JellyfinBaseUrl);
+		var apiKey = settings.JellyfinApiKey!;
+
+		var userId = await ResolveAdminUserIdAsync(httpClient, baseUrl, apiKey, cancellationToken).ConfigureAwait(false);
+		if (string.IsNullOrWhiteSpace(userId))
+		{
+			throw new InvalidOperationException("Jellyfin did not return any users.");
+		}
+
+		var itemId = await FindMovieItemIdAsync(httpClient, baseUrl, apiKey, userId, tmdbId, cancellationToken).ConfigureAwait(false);
+		if (string.IsNullOrWhiteSpace(itemId))
+		{
+			throw new InvalidOperationException("Jellyfin item not found.");
+		}
+
+		var upstreamUri = new Uri($"{baseUrl}Videos/{Uri.EscapeDataString(itemId)}/stream?static=true", UriKind.Absolute);
+		return new UpstreamPlaybackRequest(
+			Uri: upstreamUri,
+			Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+			{
+				["X-Emby-Token"] = apiKey
+			});
+	}
+
+	private static async Task<string?> ResolveAdminUserIdAsync(HttpClient client, string baseUrl, string apiKey, CancellationToken cancellationToken)
+	{
+		var uri = new Uri($"{baseUrl}Users", UriKind.Absolute);
+		using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+		request.Headers.Accept.ParseAdd("application/json");
+		request.Headers.Add("X-Emby-Token", apiKey);
+
+		using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+		response.EnsureSuccessStatusCode();
+
+		var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+		var users = JsonSerializer.Deserialize<List<UserDto>>(json, Json) ?? [];
+		if (users.Count == 0)
+		{
+			return null;
+		}
+
+		var admin = users.FirstOrDefault(u => u.Policy?.IsAdministrator == true);
+		return (admin ?? users[0]).Id?.Trim();
+	}
+
+	private async Task<string?> FindMovieItemIdAsync(
+		HttpClient client,
+		string baseUrl,
+		string apiKey,
+		string userId,
+		int tmdbId,
+		CancellationToken cancellationToken)
+	{
+		// Jellyfin doesn't have a single stable query shape across all versions/plugins.
+		// Try a few safe variants.
+		var candidates = new[]
+		{
+			$"Users/{Uri.EscapeDataString(userId)}/Items?IncludeItemTypes=Movie&Recursive=true&Limit=1&Fields=ProviderIds&AnyProviderIdEquals=tmdb.{tmdbId}",
+			$"Users/{Uri.EscapeDataString(userId)}/Items?IncludeItemTypes=Movie&Recursive=true&Limit=1&Fields=ProviderIds&AnyProviderIdEquals=Tmdb.{tmdbId}",
+		};
+
+		foreach (var query in candidates)
+		{
+			var uri = new Uri($"{baseUrl}{query}", UriKind.Absolute);
+			using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+			request.Headers.Accept.ParseAdd("application/json");
+			request.Headers.Add("X-Emby-Token", apiKey);
+			using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+			if (!response.IsSuccessStatusCode)
+			{
+				continue;
+			}
+
+			var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+			var dto = JsonSerializer.Deserialize<ItemsResponseDto>(json, Json);
+			var id = dto?.Items?.FirstOrDefault()?.Id;
+			if (!string.IsNullOrWhiteSpace(id))
+			{
+				return id.Trim();
+			}
+		}
+
+		logger.LogDebug("jellyfin item id lookup failed. TmdbId={TmdbId}", tmdbId);
+		return null;
+	}
+
+	private static string NormalizeJellyfinBaseUrl(string baseUrl)
+	{
+		var trimmed = (baseUrl ?? string.Empty).Trim().TrimEnd('/');
+		return string.IsNullOrWhiteSpace(trimmed) ? string.Empty : trimmed + "/";
+	}
+
+	private sealed record UserDto(
+		[property: JsonPropertyName("Id")] string? Id,
+		[property: JsonPropertyName("Policy")] UserPolicyDto? Policy);
+
+	private sealed record UserPolicyDto([property: JsonPropertyName("IsAdministrator")] bool IsAdministrator);
+
+	private sealed record ItemsResponseDto(
+		[property: JsonPropertyName("Items")] List<ItemDto>? Items,
+		[property: JsonPropertyName("TotalRecordCount")] int TotalRecordCount);
+
+	private sealed record ItemDto([property: JsonPropertyName("Id")] string? Id);
+}

--- a/src/Tindarr.Infrastructure/Playback/Providers/PlexPlaybackProvider.cs
+++ b/src/Tindarr.Infrastructure/Playback/Providers/PlexPlaybackProvider.cs
@@ -1,0 +1,111 @@
+using System.Net.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Tindarr.Application.Abstractions.Integrations;
+using Tindarr.Application.Abstractions.Persistence;
+using Tindarr.Application.Interfaces.Playback;
+using Tindarr.Application.Options;
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Infrastructure.Playback.Providers;
+
+public sealed class PlexPlaybackProvider(
+	IServiceSettingsRepository settingsRepo,
+	IPlexLibraryCacheRepository plexCache,
+	HttpClient httpClient,
+	IOptions<PlexOptions> plexOptions,
+	ILogger<PlexPlaybackProvider> logger) : IPlaybackProvider
+{
+	private readonly PlexOptions _plexOptions = plexOptions.Value;
+
+	// For casting, Plex must choose a playback profile that matches the actual receiver capabilities.
+	// If we identify as an unknown platform/device, Plex refuses to pick a profile and will not transcode.
+	private const string ChromecastPlatform = "Chromecast";
+	private const string ChromecastDevice = "Chromecast";
+	private const string ChromecastModel = "Chromecast";
+	private const string ChromecastPlatformVersion = "1";
+
+	public ServiceType ServiceType => ServiceType.Plex;
+
+	public async Task<UpstreamPlaybackRequest> BuildMovieStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
+	{
+		_ = httpClient;
+
+		if (tmdbId <= 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(tmdbId));
+		}
+
+		var server = await settingsRepo.GetAsync(scope, cancellationToken).ConfigureAwait(false);
+		if (server is null || string.IsNullOrWhiteSpace(server.PlexServerUri))
+		{
+			throw new InvalidOperationException("Plex server is not configured.");
+		}
+
+		var account = await settingsRepo.GetAsync(new ServiceScope(ServiceType.Plex, PlexConstants.AccountServerId), cancellationToken).ConfigureAwait(false);
+		var accessToken = !string.IsNullOrWhiteSpace(server.PlexServerAccessToken)
+			? server.PlexServerAccessToken!
+			: account?.PlexAuthToken;
+
+		if (string.IsNullOrWhiteSpace(accessToken))
+		{
+			throw new InvalidOperationException("Plex is not authenticated.");
+		}
+
+		var ratingKey = await plexCache.TryGetRatingKeyAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+		if (string.IsNullOrWhiteSpace(ratingKey))
+		{
+			throw new InvalidOperationException("Plex item not found in cache. Sync Plex library first.");
+		}
+
+		var clientIdentifier = server.PlexClientIdentifier ?? account?.PlexClientIdentifier;
+		if (string.IsNullOrWhiteSpace(clientIdentifier))
+		{
+			throw new InvalidOperationException("Plex client identifier is not configured.");
+		}
+
+		// IMPORTANT:
+		// Do NOT stream Plex Part.Key directly (or with download=1).
+		// Chromecast frequently can't decode the source audio codec (e.g. DTS), resulting in silent playback.
+		// Use Plex's universal transcode endpoint to force a Chromecast-friendly container/audio.
+		var baseUrl = NormalizeBaseUrl(server.PlexServerUri!);
+		var path = $"/library/metadata/{ratingKey.Trim()}";
+		var upstreamUri = new Uri(
+			$"{baseUrl}video/:/transcode/universal/start?" +
+			$"path={Uri.EscapeDataString(path)}" +
+			"&mediaIndex=0" +
+			"&partIndex=0" +
+			"&protocol=http" +
+			"&format=mp4" +
+			"&directPlay=0" +
+			"&directStream=1" +
+			"&fastSeek=1" +
+			$"&session={Uri.EscapeDataString(clientIdentifier.Trim())}",
+			UriKind.Absolute);
+
+		logger.LogDebug("plex upstream stream request built. TmdbId={TmdbId} RatingKey={RatingKey} Uri={Uri}", tmdbId, ratingKey, upstreamUri);
+
+		return new UpstreamPlaybackRequest(
+			Uri: upstreamUri,
+			Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+			{
+				["X-Plex-Token"] = accessToken,
+				["X-Plex-Client-Identifier"] = clientIdentifier.Trim(),
+				["X-Plex-Product"] = _plexOptions.Product,
+				// Identify as Chromecast so Plex can choose a matching client profile for audio/video compatibility.
+				["X-Plex-Platform"] = ChromecastPlatform,
+				["X-Plex-Platform-Version"] = ChromecastPlatformVersion,
+				["X-Plex-Device"] = ChromecastDevice,
+				["X-Plex-Model"] = ChromecastModel,
+				["X-Plex-Version"] = _plexOptions.Version,
+			});
+	}
+
+	private static string NormalizeBaseUrl(string baseUrl)
+	{
+		var trimmed = (baseUrl ?? string.Empty).Trim().TrimEnd('/');
+		return string.IsNullOrWhiteSpace(trimmed) ? string.Empty : trimmed + "/";
+	}
+
+	// Intentionally no Plex metadata DTOs here: this provider streams via transcode endpoint.
+}

--- a/src/Tindarr.Infrastructure/PlexCache/Entities/PlexDeckEntryEntity.cs
+++ b/src/Tindarr.Infrastructure/PlexCache/Entities/PlexDeckEntryEntity.cs
@@ -1,0 +1,39 @@
+namespace Tindarr.Infrastructure.PlexCache.Entities;
+
+public sealed class PlexDeckEntryEntity
+{
+	public int Id { get; set; }
+	public string ServerId { get; set; } = string.Empty;
+	public int TmdbId { get; set; }
+
+	public string Title { get; set; } = string.Empty;
+	public string? Overview { get; set; }
+	public string? PosterUrl { get; set; }
+	public string? BackdropUrl { get; set; }
+
+	public int? ReleaseYear { get; set; }
+	public string? MpaaRating { get; set; }
+	public double? Rating { get; set; }
+	public int? VoteCount { get; set; }
+	public string? OriginalLanguage { get; set; }
+	public int? RuntimeMinutes { get; set; }
+
+	public bool IsAdult { get; set; }
+	public DateTimeOffset UpdatedAtUtc { get; set; }
+}
+
+public sealed class PlexDeckGenreEntity
+{
+	public int Id { get; set; }
+	public string ServerId { get; set; } = string.Empty;
+	public int TmdbId { get; set; }
+	public string Genre { get; set; } = string.Empty;
+}
+
+public sealed class PlexDeckRegionEntity
+{
+	public int Id { get; set; }
+	public string ServerId { get; set; } = string.Empty;
+	public int TmdbId { get; set; }
+	public string Region { get; set; } = string.Empty;
+}

--- a/src/Tindarr.Infrastructure/PlexCache/PlexCacheDbContext.cs
+++ b/src/Tindarr.Infrastructure/PlexCache/PlexCacheDbContext.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Tindarr.Infrastructure.PlexCache.Entities;
 
 namespace Tindarr.Infrastructure.PlexCache;
@@ -6,10 +8,18 @@ namespace Tindarr.Infrastructure.PlexCache;
 public sealed class PlexCacheDbContext(DbContextOptions<PlexCacheDbContext> options) : DbContext(options)
 {
 	public DbSet<PlexLibraryCacheItemEntity> LibraryItems => Set<PlexLibraryCacheItemEntity>();
+	public DbSet<PlexDeckEntryEntity> DeckEntries => Set<PlexDeckEntryEntity>();
+	public DbSet<PlexDeckGenreEntity> DeckGenres => Set<PlexDeckGenreEntity>();
+	public DbSet<PlexDeckRegionEntity> DeckRegions => Set<PlexDeckRegionEntity>();
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{
 		base.OnModelCreating(modelBuilder);
+
+		// SQLite can't translate ORDER BY over DateTimeOffset. Store as a UTC round-trip string instead.
+		var utcDateTimeOffsetStringConverter = new ValueConverter<DateTimeOffset, string>(
+			v => v.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
+			v => DateTimeOffset.Parse(v, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
 
 		modelBuilder.Entity<PlexLibraryCacheItemEntity>(builder =>
 		{
@@ -17,7 +27,47 @@ public sealed class PlexCacheDbContext(DbContextOptions<PlexCacheDbContext> opti
 			builder.HasKey(x => x.Id);
 			builder.Property(x => x.ServerId).IsRequired();
 			builder.HasIndex(x => new { x.ServerId, x.TmdbId }).IsUnique();
-			builder.Property(x => x.UpdatedAtUtc).IsRequired();
+			builder.Property(x => x.UpdatedAtUtc)
+				.IsRequired()
+				.HasConversion(utcDateTimeOffsetStringConverter)
+				.HasColumnType("TEXT");
+		});
+
+		modelBuilder.Entity<PlexDeckEntryEntity>(builder =>
+		{
+			builder.ToTable("PlexDeckEntries");
+			builder.HasKey(x => x.Id);
+			builder.Property(x => x.ServerId).IsRequired();
+			builder.Property(x => x.Title).IsRequired();
+			builder.Property(x => x.UpdatedAtUtc)
+				.IsRequired()
+				.HasConversion(utcDateTimeOffsetStringConverter)
+				.HasColumnType("TEXT");
+			builder.HasIndex(x => new { x.ServerId, x.TmdbId }).IsUnique();
+			builder.HasIndex(x => new { x.ServerId, x.ReleaseYear });
+			builder.HasIndex(x => new { x.ServerId, x.Rating });
+			builder.HasIndex(x => new { x.ServerId, x.OriginalLanguage });
+			builder.HasIndex(x => new { x.ServerId, x.IsAdult });
+		});
+
+		modelBuilder.Entity<PlexDeckGenreEntity>(builder =>
+		{
+			builder.ToTable("PlexDeckGenres");
+			builder.HasKey(x => x.Id);
+			builder.Property(x => x.ServerId).IsRequired();
+			builder.Property(x => x.Genre).IsRequired();
+			builder.HasIndex(x => new { x.ServerId, x.TmdbId });
+			builder.HasIndex(x => new { x.ServerId, x.Genre });
+		});
+
+		modelBuilder.Entity<PlexDeckRegionEntity>(builder =>
+		{
+			builder.ToTable("PlexDeckRegions");
+			builder.HasKey(x => x.Id);
+			builder.Property(x => x.ServerId).IsRequired();
+			builder.Property(x => x.Region).IsRequired();
+			builder.HasIndex(x => new { x.ServerId, x.TmdbId });
+			builder.HasIndex(x => new { x.ServerId, x.Region });
 		});
 	}
 }

--- a/src/Tindarr.Infrastructure/PlexCache/PlexCacheServiceCollectionExtensions.cs
+++ b/src/Tindarr.Infrastructure/PlexCache/PlexCacheServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ public static class PlexCacheServiceCollectionExtensions
 		});
 
 		services.AddScoped<IPlexLibraryCacheRepository, PlexLibraryCacheRepository>();
+		services.AddScoped<IPlexDeckIndexRepository, PlexDeckIndexRepository>();
 		return services;
 	}
 

--- a/src/Tindarr.Infrastructure/PlexCache/Repositories/PlexDeckIndexRepository.cs
+++ b/src/Tindarr.Infrastructure/PlexCache/Repositories/PlexDeckIndexRepository.cs
@@ -1,0 +1,299 @@
+using Microsoft.EntityFrameworkCore;
+using Tindarr.Application.Abstractions.Persistence;
+using Tindarr.Contracts.Movies;
+using Tindarr.Domain.Common;
+using Tindarr.Domain.Interactions;
+using Tindarr.Infrastructure.PlexCache.Entities;
+
+namespace Tindarr.Infrastructure.PlexCache.Repositories;
+
+public sealed class PlexDeckIndexRepository(PlexCacheDbContext db) : IPlexDeckIndexRepository
+{
+	public async Task UpsertAsync(ServiceScope scope, IReadOnlyCollection<MovieDetailsDto> details, DateTimeOffset updatedAtUtc, CancellationToken cancellationToken)
+	{
+		if (scope.ServiceType != ServiceType.Plex)
+		{
+			return;
+		}
+		if (details.Count == 0)
+		{
+			return;
+		}
+
+		var serverId = scope.ServerId;
+		var tmdbIds = details.Where(d => d.TmdbId > 0).Select(d => d.TmdbId).Distinct().ToList();
+		if (tmdbIds.Count == 0)
+		{
+			return;
+		}
+
+		// SQLite has a relatively small parameter limit; chunk deletes.
+		const int chunkSize = 400;
+		await using var tx = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+		try
+		{
+			for (var i = 0; i < tmdbIds.Count; i += chunkSize)
+			{
+				var chunk = tmdbIds.Skip(i).Take(chunkSize).ToList();
+
+				await db.DeckGenres
+					.Where(x => x.ServerId == serverId && chunk.Contains(x.TmdbId))
+					.ExecuteDeleteAsync(cancellationToken)
+					.ConfigureAwait(false);
+
+				await db.DeckRegions
+					.Where(x => x.ServerId == serverId && chunk.Contains(x.TmdbId))
+					.ExecuteDeleteAsync(cancellationToken)
+					.ConfigureAwait(false);
+
+				await db.DeckEntries
+					.Where(x => x.ServerId == serverId && chunk.Contains(x.TmdbId))
+					.ExecuteDeleteAsync(cancellationToken)
+					.ConfigureAwait(false);
+			}
+
+			var entryRows = new List<PlexDeckEntryEntity>(details.Count);
+			var genreRows = new List<PlexDeckGenreEntity>();
+			var regionRows = new List<PlexDeckRegionEntity>();
+
+			foreach (var d in details)
+			{
+				if (d.TmdbId <= 0)
+				{
+					continue;
+				}
+
+				var isAdult = IsAdultRating(d.MpaaRating);
+				entryRows.Add(new PlexDeckEntryEntity
+				{
+					ServerId = serverId,
+					TmdbId = d.TmdbId,
+					Title = (d.Title ?? string.Empty).Trim(),
+					Overview = d.Overview,
+					PosterUrl = d.PosterUrl,
+					BackdropUrl = d.BackdropUrl,
+					ReleaseYear = d.ReleaseYear,
+					MpaaRating = string.IsNullOrWhiteSpace(d.MpaaRating) ? null : d.MpaaRating.Trim(),
+					Rating = d.Rating,
+					VoteCount = d.VoteCount,
+					OriginalLanguage = string.IsNullOrWhiteSpace(d.OriginalLanguage) ? null : d.OriginalLanguage.Trim(),
+					RuntimeMinutes = d.RuntimeMinutes,
+					IsAdult = isAdult,
+					UpdatedAtUtc = updatedAtUtc
+				});
+
+				if (d.Genres is { Count: > 0 })
+				{
+					foreach (var g in d.Genres)
+					{
+						var genre = (g ?? string.Empty).Trim();
+						if (genre.Length == 0)
+						{
+							continue;
+						}
+						genreRows.Add(new PlexDeckGenreEntity { ServerId = serverId, TmdbId = d.TmdbId, Genre = genre });
+					}
+				}
+
+				if (d.Regions is { Count: > 0 })
+				{
+					foreach (var r in d.Regions)
+					{
+						var region = (r ?? string.Empty).Trim();
+						if (region.Length == 0)
+						{
+							continue;
+						}
+						regionRows.Add(new PlexDeckRegionEntity { ServerId = serverId, TmdbId = d.TmdbId, Region = region });
+					}
+				}
+			}
+
+			if (entryRows.Count == 0)
+			{
+				await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+				return;
+			}
+
+			db.DeckEntries.AddRange(entryRows);
+			if (genreRows.Count > 0)
+			{
+				db.DeckGenres.AddRange(genreRows);
+			}
+			if (regionRows.Count > 0)
+			{
+				db.DeckRegions.AddRange(regionRows);
+			}
+
+			await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+			await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+		}
+		catch
+		{
+			await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
+			throw;
+		}
+	}
+
+	public async Task<IReadOnlyList<SwipeCard>> QueryAsync(ServiceScope scope, UserPreferencesRecord preferences, int limit, CancellationToken cancellationToken)
+	{
+		if (scope.ServiceType != ServiceType.Plex)
+		{
+			return [];
+		}
+		limit = Math.Clamp(limit, 1, 500);
+
+	var serverId = scope.ServerId;
+	var q = db.DeckEntries.AsNoTracking().Where(x => x.ServerId == serverId);
+
+		if (preferences.MinReleaseYear is { } minYear)
+		{
+			q = q.Where(x => x.ReleaseYear != null && x.ReleaseYear.Value >= minYear);
+		}
+
+		if (preferences.MaxReleaseYear is { } maxYear)
+		{
+			q = q.Where(x => x.ReleaseYear != null && x.ReleaseYear.Value <= maxYear);
+		}
+
+		if (preferences.MinRating is { } minRating)
+		{
+			q = q.Where(x => x.Rating != null && x.Rating.Value >= minRating);
+		}
+
+		if (preferences.MaxRating is { } maxRating)
+		{
+			q = q.Where(x => x.Rating != null && x.Rating.Value <= maxRating);
+		}
+
+		if (!preferences.IncludeAdult)
+		{
+			q = q.Where(x => !x.IsAdult);
+		}
+
+		if (preferences.PreferredOriginalLanguages is { Count: > 0 })
+		{
+			var langs = preferences.PreferredOriginalLanguages.Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim().ToLowerInvariant()).Distinct().ToList();
+			if (langs.Count > 0)
+			{
+				q = q.Where(x => x.OriginalLanguage != null && langs.Contains(x.OriginalLanguage.ToLower()));
+			}
+		}
+
+		if (preferences.ExcludedOriginalLanguages is { Count: > 0 })
+		{
+			var langs = preferences.ExcludedOriginalLanguages.Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim().ToLowerInvariant()).Distinct().ToList();
+			if (langs.Count > 0)
+			{
+				q = q.Where(x => x.OriginalLanguage == null || !langs.Contains(x.OriginalLanguage.ToLower()));
+			}
+		}
+
+		// Genre filtering: preferences store TMDB genre IDs, but details store genre names.
+		// Map IDs -> names using the same hardcoded map from PlexService.
+		var preferredGenreNames = MapGenreNames(preferences.PreferredGenres);
+		if (preferredGenreNames.Count > 0)
+		{
+			q = q.Where(e => db.DeckGenres.AsNoTracking().Any(g => g.ServerId == serverId && g.TmdbId == e.TmdbId && preferredGenreNames.Contains(g.Genre)));
+		}
+
+		var excludedGenreNames = MapGenreNames(preferences.ExcludedGenres);
+		if (excludedGenreNames.Count > 0)
+		{
+			q = q.Where(e => !db.DeckGenres.AsNoTracking().Any(g => g.ServerId == serverId && g.TmdbId == e.TmdbId && excludedGenreNames.Contains(g.Genre)));
+		}
+
+		if (preferences.PreferredRegions is { Count: > 0 })
+		{
+			var regions = preferences.PreferredRegions.Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).Distinct().ToList();
+			if (regions.Count > 0)
+			{
+				q = q.Where(e => db.DeckRegions.AsNoTracking().Any(r => r.ServerId == serverId && r.TmdbId == e.TmdbId && regions.Contains(r.Region)));
+			}
+		}
+
+		if (preferences.ExcludedRegions is { Count: > 0 })
+		{
+			var regions = preferences.ExcludedRegions.Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).Distinct().ToList();
+			if (regions.Count > 0)
+			{
+				q = q.Where(e => !db.DeckRegions.AsNoTracking().Any(r => r.ServerId == serverId && r.TmdbId == e.TmdbId && regions.Contains(r.Region)));
+			}
+		}
+
+		var rows = await q
+			.OrderByDescending(x => x.UpdatedAtUtc)
+			.ThenBy(x => x.TmdbId)
+			.Take(limit)
+			.Select(x => new SwipeCard(
+				x.TmdbId,
+				x.Title,
+				x.Overview,
+				x.PosterUrl,
+				x.BackdropUrl,
+				x.ReleaseYear,
+				x.Rating))
+			.ToListAsync(cancellationToken)
+			.ConfigureAwait(false);
+
+		return rows;
+	}
+
+	private static bool IsAdultRating(string? mpaa)
+	{
+		if (string.IsNullOrWhiteSpace(mpaa))
+		{
+			return false;
+		}
+
+		var v = mpaa.Trim();
+		return v.Equals("NC-17", StringComparison.OrdinalIgnoreCase)
+			|| v.Equals("X", StringComparison.OrdinalIgnoreCase)
+			|| v.Equals("XXX", StringComparison.OrdinalIgnoreCase)
+			|| v.Equals("TV-MA", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static HashSet<string> MapGenreNames(IReadOnlyList<int> genreIds)
+	{
+		if (genreIds is not { Count: > 0 })
+		{
+			return new HashSet<string>(StringComparer.Ordinal);
+		}
+
+		// Keep in sync with PlexService.TmdbGenreMap.
+		static string? Map(int id) => id switch
+		{
+			28 => "Action",
+			12 => "Adventure",
+			16 => "Animation",
+			35 => "Comedy",
+			80 => "Crime",
+			99 => "Documentary",
+			18 => "Drama",
+			10751 => "Family",
+			14 => "Fantasy",
+			36 => "History",
+			27 => "Horror",
+			10402 => "Music",
+			9648 => "Mystery",
+			10749 => "Romance",
+			878 => "Science Fiction",
+			10770 => "TV Movie",
+			53 => "Thriller",
+			10752 => "War",
+			37 => "Western",
+			_ => null
+		};
+
+		var set = new HashSet<string>(StringComparer.Ordinal);
+		foreach (var id in genreIds)
+		{
+			var name = Map(id);
+			if (!string.IsNullOrWhiteSpace(name))
+			{
+				set.Add(name);
+			}
+		}
+		return set;
+	}
+}

--- a/src/Tindarr.Infrastructure/Security/CastUrlTokenService.cs
+++ b/src/Tindarr.Infrastructure/Security/CastUrlTokenService.cs
@@ -1,0 +1,138 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Tindarr.Application.Abstractions.Security;
+using Tindarr.Application.Options;
+
+namespace Tindarr.Infrastructure.Security;
+
+public sealed class CastUrlTokenService(
+	ITokenSigningKeyStore keyStore,
+	IOptions<PlaybackOptions> options) : ICastUrlTokenService
+{
+	private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+	private readonly PlaybackOptions _options = options.Value;
+
+	public string IssueRoomQrToken(string roomId, DateTimeOffset nowUtc)
+	{
+		if (string.IsNullOrWhiteSpace(roomId))
+		{
+			throw new ArgumentException("roomId is required.", nameof(roomId));
+		}
+
+		var exp = nowUtc.AddMinutes(Math.Clamp(_options.TokenMinutes, 1, 60));
+		var payload = new CastTokenPayload(
+			Kid: keyStore.GetActiveKeyId(),
+			Typ: "qr",
+			Rid: roomId.Trim(),
+			Exp: exp.ToUnixTimeSeconds());
+
+		var payloadBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload, Json));
+		var payloadB64 = Base64UrlEncoder.Encode(payloadBytes);
+
+		var active = keyStore.GetActiveSigningKey();
+		var sigBytes = Sign(payloadB64, active.KeyMaterial);
+		var sigB64 = Base64UrlEncoder.Encode(sigBytes);
+		return $"{payloadB64}.{sigB64}";
+	}
+
+	public bool TryValidateRoomQrToken(string token, string roomId, DateTimeOffset nowUtc)
+	{
+		if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(roomId))
+		{
+			return false;
+		}
+
+		var parts = token.Split('.', 2);
+		if (parts.Length != 2)
+		{
+			return false;
+		}
+
+		var payloadB64 = parts[0];
+		var sigB64 = parts[1];
+		byte[] payloadBytes;
+		byte[] sigBytes;
+		try
+		{
+			payloadBytes = Base64UrlEncoder.DecodeBytes(payloadB64);
+			sigBytes = Base64UrlEncoder.DecodeBytes(sigB64);
+		}
+		catch
+		{
+			return false;
+		}
+
+		CastTokenPayload? payload;
+		try
+		{
+			payload = JsonSerializer.Deserialize<CastTokenPayload>(payloadBytes, Json);
+		}
+		catch
+		{
+			return false;
+		}
+
+		if (payload is null)
+		{
+			return false;
+		}
+
+		if (!string.Equals(payload.Typ, "qr", StringComparison.OrdinalIgnoreCase))
+		{
+			return false;
+		}
+		if (!string.Equals(payload.Rid, roomId.Trim(), StringComparison.Ordinal))
+		{
+			return false;
+		}
+		if (payload.Exp <= 0 || nowUtc.ToUnixTimeSeconds() > payload.Exp)
+		{
+			return false;
+		}
+
+		var keys = keyStore.GetAllSigningKeys();
+		foreach (var key in keys)
+		{
+			if (!string.IsNullOrWhiteSpace(payload.Kid)
+				&& !string.Equals(key.KeyId, payload.Kid, StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+
+			var expectedSig = Sign(payloadB64, key.KeyMaterial);
+			if (CryptographicOperations.FixedTimeEquals(expectedSig, sigBytes))
+			{
+				return true;
+			}
+		}
+
+		if (string.IsNullOrWhiteSpace(payload.Kid))
+		{
+			foreach (var key in keys)
+			{
+				var expectedSig = Sign(payloadB64, key.KeyMaterial);
+				if (CryptographicOperations.FixedTimeEquals(expectedSig, sigBytes))
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private static byte[] Sign(string payloadB64, byte[] keyMaterial)
+	{
+		using var hmac = new HMACSHA256(keyMaterial);
+		return hmac.ComputeHash(Encoding.UTF8.GetBytes(payloadB64));
+	}
+
+	private sealed record CastTokenPayload(
+		string Kid,
+		string Typ,
+		string Rid,
+		long Exp);
+}

--- a/src/Tindarr.Infrastructure/Security/PlaybackTokenService.cs
+++ b/src/Tindarr.Infrastructure/Security/PlaybackTokenService.cs
@@ -1,0 +1,150 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Tindarr.Application.Abstractions.Security;
+using Tindarr.Application.Options;
+using Tindarr.Domain.Common;
+
+namespace Tindarr.Infrastructure.Security;
+
+public sealed class PlaybackTokenService(
+	ITokenSigningKeyStore keyStore,
+	IOptions<PlaybackOptions> options) : IPlaybackTokenService
+{
+	private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+	private readonly PlaybackOptions _options = options.Value;
+
+	public string IssueMovieToken(ServiceScope scope, int tmdbId, DateTimeOffset nowUtc)
+	{
+		if (tmdbId <= 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(tmdbId), "tmdbId must be positive.");
+		}
+
+		var exp = nowUtc.AddMinutes(Math.Clamp(_options.TokenMinutes, 1, 60));
+		var payload = new PlaybackTokenPayload(
+			Kid: keyStore.GetActiveKeyId(),
+			Svc: scope.ServiceType.ToString().ToLowerInvariant(),
+			Sid: scope.ServerId,
+			Tmdb: tmdbId,
+			Exp: exp.ToUnixTimeSeconds());
+
+		var payloadBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload, Json));
+		var payloadB64 = Base64UrlEncoder.Encode(payloadBytes);
+
+		var active = keyStore.GetActiveSigningKey();
+		var sigBytes = Sign(payloadB64, active.KeyMaterial);
+		var sigB64 = Base64UrlEncoder.Encode(sigBytes);
+		return $"{payloadB64}.{sigB64}";
+	}
+
+	public bool TryValidateMovieToken(string token, ServiceScope scope, int tmdbId, DateTimeOffset nowUtc)
+	{
+		if (string.IsNullOrWhiteSpace(token))
+		{
+			return false;
+		}
+
+		var parts = token.Split('.', 2);
+		if (parts.Length != 2)
+		{
+			return false;
+		}
+
+		var payloadB64 = parts[0];
+		var sigB64 = parts[1];
+		byte[] payloadBytes;
+		byte[] sigBytes;
+		try
+		{
+			payloadBytes = Base64UrlEncoder.DecodeBytes(payloadB64);
+			sigBytes = Base64UrlEncoder.DecodeBytes(sigB64);
+		}
+		catch
+		{
+			return false;
+		}
+
+		PlaybackTokenPayload? payload;
+		try
+		{
+			payload = JsonSerializer.Deserialize<PlaybackTokenPayload>(payloadBytes, Json);
+		}
+		catch
+		{
+			return false;
+		}
+
+		if (payload is null)
+		{
+			return false;
+		}
+
+		var expectedSvc = scope.ServiceType.ToString().ToLowerInvariant();
+		if (!string.Equals(payload.Svc, expectedSvc, StringComparison.OrdinalIgnoreCase))
+		{
+			return false;
+		}
+
+		if (!string.Equals(payload.Sid, scope.ServerId, StringComparison.Ordinal))
+		{
+			return false;
+		}
+
+		if (payload.Tmdb != tmdbId)
+		{
+			return false;
+		}
+
+		if (payload.Exp <= 0 || nowUtc.ToUnixTimeSeconds() > payload.Exp)
+		{
+			return false;
+		}
+
+		var keys = keyStore.GetAllSigningKeys();
+		foreach (var key in keys)
+		{
+			if (!string.IsNullOrWhiteSpace(payload.Kid)
+				&& !string.Equals(key.KeyId, payload.Kid, StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+
+			var expectedSig = Sign(payloadB64, key.KeyMaterial);
+			if (CryptographicOperations.FixedTimeEquals(expectedSig, sigBytes))
+			{
+				return true;
+			}
+		}
+
+		// Rotation support: if kid is missing/unknown, try all keys.
+		if (string.IsNullOrWhiteSpace(payload.Kid))
+		{
+			foreach (var key in keys)
+			{
+				var expectedSig = Sign(payloadB64, key.KeyMaterial);
+				if (CryptographicOperations.FixedTimeEquals(expectedSig, sigBytes))
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private static byte[] Sign(string payloadB64, byte[] keyMaterial)
+	{
+		using var hmac = new HMACSHA256(keyMaterial);
+		return hmac.ComputeHash(Encoding.UTF8.GetBytes(payloadB64));
+	}
+
+	private sealed record PlaybackTokenPayload(
+		string Kid,
+		string Svc,
+		string Sid,
+		int Tmdb,
+		long Exp);
+}

--- a/src/Tindarr.Infrastructure/Tindarr.Infrastructure.csproj
+++ b/src/Tindarr.Infrastructure/Tindarr.Infrastructure.csproj
@@ -23,5 +23,6 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
     <PackageReference Include="System.Threading.RateLimiting" Version="10.0.2" />
+    <PackageReference Include="SharpCaster" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -11,6 +11,7 @@ import RoomPage from "./pages/RoomPage";
 import NotFoundPage from "./pages/NotFoundPage";
 import { useAuth } from "./auth/AuthContext";
 import TmdbBulkJobToast from "./components/TmdbBulkJobToast";
+import PlexBulkJobToast from "./components/PlexBulkJobToast";
 import { fetchConfiguredScopes } from "./api/client";
 import type { ServiceScopeOptionDto } from "./api/contracts";
 import { getServiceScope, SERVICE_SCOPE_UPDATED_EVENT, setServiceScopeAndNotify, type ServiceScope } from "./serviceScope";
@@ -210,6 +211,7 @@ function AppLayout() {
       </main>
 
       <TmdbBulkJobToast />
+      <PlexBulkJobToast />
     </div>
   );
 }

--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -179,6 +179,21 @@ export type RoomMatchesResponse = {
   tmdbIds: number[];
 };
 
+export type CastDeviceDto = {
+  id: string;
+  name: string;
+  address: string | null;
+  port: number;
+};
+
+export type CastMovieRequest = {
+  deviceId: string;
+  serviceType: string;
+  serverId: string;
+  tmdbId: number;
+  title?: string | null;
+};
+
 export type MovieDetailsDto = {
   tmdbId: number;
   title: string;
@@ -304,6 +319,33 @@ export type PlexServerDto = {
   online: boolean;
   lastLibrarySyncUtc: string | null;
   updatedAtUtc: string;
+};
+
+export type PlexLibrarySyncStatusDto = {
+  serviceType: string;
+  serverId: string;
+  state: string;
+  totalSections: number;
+  processedSections: number;
+  totalItems: number;
+  processedItems: number;
+  tmdbIdsFound: number;
+  startedAtUtc: string | null;
+  finishedAtUtc: string | null;
+  message: string | null;
+  updatedAtUtc: string;
+};
+
+export type PlexLibraryMissingDetailsItemDto = {
+  tmdbId: number;
+  title: string;
+};
+
+export type PlexLibraryMissingDetailsResponse = {
+  serviceType: string;
+  serverId: string;
+  count: number;
+  items: PlexLibraryMissingDetailsItemDto[];
 };
 
 export type RadarrSettingsDto = {

--- a/ui/src/components/PlexBulkJobToast.tsx
+++ b/ui/src/components/PlexBulkJobToast.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  ensurePlexBulkJobRunner,
+  getPlexBulkJob,
+  requestStopPlexBulkJob,
+  subscribePlexBulkJob,
+  type PlexBulkJob
+} from "../plex/plexBulkJob";
+
+function titleFor(job: PlexBulkJob) {
+  return job.kind === "details" ? "Plex: Fetch all details" : "Plex: Fetch all images";
+}
+
+export default function PlexBulkJobToast() {
+  const [job, setJob] = useState<PlexBulkJob | null>(() => getPlexBulkJob());
+
+  useEffect(() => {
+    ensurePlexBulkJobRunner();
+    return subscribePlexBulkJob(setJob);
+  }, []);
+
+  const visible = useMemo(() => Boolean(job?.running), [job?.running]);
+
+  if (!visible || !job) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        right: "1rem",
+        bottom: "5.5rem",
+        zIndex: 1000,
+        width: "min(420px, calc(100vw - 2rem))"
+      }}
+    >
+      <div className="deck__state" style={{ textAlign: "left" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: "0.75rem", alignItems: "flex-start" }}>
+          <div style={{ display: "grid", gap: "0.25rem" }}>
+            <div style={{ fontWeight: 700 }}>{titleFor(job)}</div>
+            <div style={{ opacity: 0.85, fontSize: "0.95rem" }}>{job.status}</div>
+            <div style={{ opacity: 0.8, fontSize: "0.9rem" }}>
+              Server: {job.serverId}
+            </div>
+            <div style={{ opacity: 0.8, fontSize: "0.9rem" }}>
+              Processed: {job.processed}{job.failures ? ` (${job.failures} failed)` : ""}
+            </div>
+          </div>
+
+          <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", justifyContent: "flex-end" }}>
+            <button
+              type="button"
+              className="button button--neutral"
+              onClick={requestStopPlexBulkJob}
+              disabled={!job.running}
+            >
+              Stop
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/SwipeDeckPage.tsx
+++ b/ui/src/pages/SwipeDeckPage.tsx
@@ -333,7 +333,7 @@ export default function SwipeDeckPage() {
         <div className="deck__state">
           No movies returned.
           <div style={{ marginTop: "0.5rem", color: "#8c93a6" }}>
-            If this is unexpected, check your TMDB configuration (TMDB_API_KEY) and preferences, then refresh.
+            If this is unexpected, check your service configuration (TMDB/Plex/Jellyfin/Emby), library sync status, and preferences, then refresh.
           </div>
         </div>
       ) : null}

--- a/ui/src/plex/plexBulkJob.ts
+++ b/ui/src/plex/plexBulkJob.ts
@@ -1,0 +1,264 @@
+import { plexListLibraryCacheMovies, tmdbFetchMovieImages, tmdbFillMovieDetails } from "../api/client";
+
+export type PlexBulkJobKind = "details" | "images";
+
+export type PlexBulkJob = {
+  version: 1;
+  kind: PlexBulkJobKind;
+  running: boolean;
+  cancelRequested: boolean;
+  status: string;
+  processed: number;
+  failures: number;
+  startedAtUtc: string;
+  updatedAtUtc: string;
+  ownerId: string | null;
+  // Images require LocalProxy to have any effect.
+  localProxyEnabled: boolean;
+  serverId: string;
+};
+
+const STORAGE_KEY = "tindarr:plexBulkJob:v1";
+const EVENT_NAME = "tindarr:plexBulkJobChanged";
+const INSTANCE_KEY = "tindarr:uiInstanceId";
+
+function getOrCreateInstanceId(): string {
+  try {
+    const existing = sessionStorage.getItem(INSTANCE_KEY);
+    if (existing) {
+      return existing;
+    }
+    const created = (globalThis.crypto && "randomUUID" in globalThis.crypto)
+      ? globalThis.crypto.randomUUID()
+      : `inst_${Math.random().toString(16).slice(2)}_${Date.now()}`;
+    sessionStorage.setItem(INSTANCE_KEY, created);
+    return created;
+  } catch {
+    return `inst_${Math.random().toString(16).slice(2)}_${Date.now()}`;
+  }
+}
+
+const instanceId = getOrCreateInstanceId();
+
+function nowUtcIso() {
+  return new Date().toISOString();
+}
+
+function readJob(): PlexBulkJob | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as PlexBulkJob;
+    if (!parsed || parsed.version !== 1) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeJob(job: PlexBulkJob | null) {
+  if (!job) {
+    localStorage.removeItem(STORAGE_KEY);
+  } else {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(job));
+  }
+  window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: job }));
+}
+
+function patchJob(patch: Partial<PlexBulkJob>) {
+  const current = readJob();
+  if (!current) {
+    return;
+  }
+  writeJob({ ...current, ...patch, updatedAtUtc: nowUtcIso() });
+}
+
+export function getPlexBulkJob(): PlexBulkJob | null {
+  return readJob();
+}
+
+export function subscribePlexBulkJob(listener: (job: PlexBulkJob | null) => void): () => void {
+  const handler = (e: Event) => {
+    const ce = e as CustomEvent<PlexBulkJob | null>;
+    listener(ce.detail ?? null);
+  };
+  const storageHandler = (e: StorageEvent) => {
+    if (e.key !== STORAGE_KEY) {
+      return;
+    }
+    listener(readJob());
+  };
+
+  window.addEventListener(EVENT_NAME, handler);
+  window.addEventListener("storage", storageHandler);
+  return () => {
+    window.removeEventListener(EVENT_NAME, handler);
+    window.removeEventListener("storage", storageHandler);
+  };
+}
+
+export function requestStopPlexBulkJob() {
+  patchJob({ cancelRequested: true, status: "Stopping…" });
+}
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+let runnerPromise: Promise<void> | null = null;
+
+export function ensurePlexBulkJobRunner() {
+  if (runnerPromise) {
+    return;
+  }
+
+  const job = readJob();
+  if (!job || !job.running) {
+    return;
+  }
+
+  runnerPromise = runExistingJob(job).finally(() => {
+    runnerPromise = null;
+  });
+}
+
+function isHeartbeatStale(job: PlexBulkJob) {
+  const updatedMs = Date.parse(job.updatedAtUtc);
+  if (!Number.isFinite(updatedMs)) {
+    return true;
+  }
+  return Date.now() - updatedMs > 15_000;
+}
+
+async function runExistingJob(initial: PlexBulkJob) {
+  const current = readJob();
+  if (!current || !current.running) {
+    return;
+  }
+
+  // Claim ownership if this is our job, or if previous owner is stale.
+  if (current.ownerId && current.ownerId !== instanceId && !isHeartbeatStale(current)) {
+    return;
+  }
+
+  writeJob({ ...current, ownerId: instanceId, updatedAtUtc: nowUtcIso() });
+
+  if (current.kind === "images" && !current.localProxyEnabled) {
+    patchJob({
+      running: false,
+      status: "Failed: LocalProxy mode is not enabled.",
+      ownerId: null
+    });
+    return;
+  }
+
+  const take = 50;
+
+  let processed = current.processed;
+  let failures = current.failures;
+
+  try {
+    patchJob({ status: current.status || "Resuming…" });
+
+    for (let loops = 0; loops < 200; loops++) {
+      const jobNow = readJob();
+      if (!jobNow || !jobNow.running) {
+        return;
+      }
+      if (jobNow.cancelRequested) {
+        patchJob({ running: false, status: `Stopped. ${processed} processed${failures ? ` (${failures} failed)` : ""}.`, ownerId: null });
+        return;
+      }
+
+      const res = await plexListLibraryCacheMovies("plex", jobNow.serverId, {
+        skip: 0,
+        take,
+        missingDetailsOnly: jobNow.kind === "details",
+        missingImagesOnly: jobNow.kind === "images"
+      });
+
+      if (!res.items || res.items.length === 0) {
+        break;
+      }
+
+      patchJob({ status: jobNow.kind === "details" ? "Filling details…" : "Fetching images…" });
+
+      for (const m of res.items) {
+        const jobLoop = readJob();
+        if (!jobLoop || !jobLoop.running) {
+          return;
+        }
+        if (jobLoop.cancelRequested) {
+          patchJob({ running: false, status: `Stopped. ${processed} processed${failures ? ` (${failures} failed)` : ""}.`, ownerId: null });
+          return;
+        }
+
+        try {
+          if (jobLoop.kind === "details") {
+            await tmdbFillMovieDetails(m.tmdbId, false);
+          } else {
+					const res = await tmdbFetchMovieImages(m.tmdbId, { includePoster: true, includeBackdrop: true });
+					if (!res.posterFetched && !res.backdropFetched) {
+						failures++;
+					}
+          }
+        } catch {
+          failures++;
+        } finally {
+          processed++;
+          patchJob({ processed, failures });
+        }
+
+        await delay(150);
+      }
+    }
+
+    patchJob({ running: false, status: `Done. ${processed} processed${failures ? ` (${failures} failed)` : ""}.`, ownerId: null, processed, failures });
+  } catch {
+    patchJob({ running: false, status: `Failed. ${processed} processed${failures ? ` (${failures} failed)` : ""}.`, ownerId: null, processed, failures });
+  }
+}
+
+async function startNewJob(kind: PlexBulkJobKind, serverId: string, localProxyEnabled: boolean) {
+  const existing = readJob();
+  if (existing?.running) {
+    return;
+  }
+
+  const normalizedServerId = (serverId ?? "").trim() || "default";
+
+  const job: PlexBulkJob = {
+    version: 1,
+    kind,
+    running: true,
+    cancelRequested: false,
+    status: kind === "details" ? "Scanning for missing details…" : "Scanning for missing images…",
+    processed: 0,
+    failures: 0,
+    startedAtUtc: nowUtcIso(),
+    updatedAtUtc: nowUtcIso(),
+    ownerId: instanceId,
+    localProxyEnabled,
+    serverId: normalizedServerId
+  };
+
+  writeJob(job);
+
+  if (!runnerPromise) {
+    runnerPromise = runExistingJob(job).finally(() => {
+      runnerPromise = null;
+    });
+  }
+}
+
+export async function startPlexBulkFetchAllDetails(serverId: string) {
+  await startNewJob("details", serverId, false);
+}
+
+export async function startPlexBulkFetchAllImages(serverId: string, localProxyEnabled: boolean) {
+  await startNewJob("images", serverId, localProxyEnabled);
+}


### PR DESCRIPTION
Summary:
- Adds casting endpoints and UI hooks to discover devices and cast QR/movie.
- Adds authenticated playback proxy endpoint for streaming to cast receivers.
- Improves Plex library sync with progress + adds Plex cache browsing/repair tools in Admin Console.

Notes:
- Generated UI build output under src/Tindarr.Api/wwwroot/ is ignored to avoid committing built assets.

Testing:
- dotnet build .\\src\\Tindarr.sln -c Debug