### PR TITLE
Join address/guest lifetime + TMDB cache settings

### DIFF
--- a/src/Tindarr.Api/Auth/Policies.cs
+++ b/src/Tindarr.Api/Auth/Policies.cs
@@ -8,6 +8,8 @@ public static class Policies
 	public const string AllowGuests = "AllowGuests";
 	public const string RoomAccess = "RoomAccess";
 
+	public const string RoomIdRouteKey = "roomId";
+
 	public const string AdminRole = "Admin";
 	public const string CuratorRole = "Curator";
 	public const string ContributorRole = "Contributor";

--- a/src/Tindarr.Api/Auth/Policies.cs
+++ b/src/Tindarr.Api/Auth/Policies.cs
@@ -5,8 +5,11 @@ public static class Policies
 	public const string AdminOnly = "AdminOnly";
 	public const string CuratorOnly = "CuratorOnly";
 	public const string ContributorOrCurator = "ContributorOrCurator";
+	public const string AllowGuests = "AllowGuests";
+	public const string RoomAccess = "RoomAccess";
 
 	public const string AdminRole = "Admin";
 	public const string CuratorRole = "Curator";
 	public const string ContributorRole = "Contributor";
+	public const string GuestRole = "Guest";
 }

--- a/src/Tindarr.Api/Auth/RoomAccessAuthorization.cs
+++ b/src/Tindarr.Api/Auth/RoomAccessAuthorization.cs
@@ -34,7 +34,7 @@ public sealed class RoomAccessAuthorizationHandler : AuthorizationHandler<RoomAc
 			return Task.CompletedTask;
 		}
 
-		if (!http.Request.RouteValues.TryGetValue("roomId", out var routeRoomObj))
+		if (!http.Request.RouteValues.TryGetValue(Policies.RoomIdRouteKey, out var routeRoomObj))
 		{
 			return Task.CompletedTask;
 		}

--- a/src/Tindarr.Api/Auth/RoomAccessAuthorization.cs
+++ b/src/Tindarr.Api/Auth/RoomAccessAuthorization.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Tindarr.Application.Abstractions.Security;
+
+namespace Tindarr.Api.Auth;
+
+public sealed class RoomAccessRequirement : IAuthorizationRequirement;
+
+public sealed class RoomAccessAuthorizationHandler : AuthorizationHandler<RoomAccessRequirement>
+{
+	protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, RoomAccessRequirement requirement)
+	{
+		if (context.User?.Identity?.IsAuthenticated != true)
+		{
+			return Task.CompletedTask;
+		}
+
+		// Non-guest users are allowed.
+		if (!context.User.IsInRole(Policies.GuestRole))
+		{
+			context.Succeed(requirement);
+			return Task.CompletedTask;
+		}
+
+		// Guest users must be tied to a specific room.
+		var claimRoomId = context.User.FindFirst(TindarrClaimTypes.RoomId)?.Value;
+		if (string.IsNullOrWhiteSpace(claimRoomId))
+		{
+			return Task.CompletedTask;
+		}
+
+		if (context.Resource is not HttpContext http)
+		{
+			return Task.CompletedTask;
+		}
+
+		if (!http.Request.RouteValues.TryGetValue("roomId", out var routeRoomObj))
+		{
+			return Task.CompletedTask;
+		}
+
+		var routeRoomId = Convert.ToString(routeRoomObj);
+		if (string.IsNullOrWhiteSpace(routeRoomId))
+		{
+			return Task.CompletedTask;
+		}
+
+		if (string.Equals(routeRoomId, claimRoomId, StringComparison.Ordinal))
+		{
+			context.Succeed(requirement);
+		}
+
+		return Task.CompletedTask;
+	}
+}

--- a/src/Tindarr.Api/Controllers/AdminController.cs
+++ b/src/Tindarr.Api/Controllers/AdminController.cs
@@ -34,10 +34,15 @@ public sealed class AdminController(
 		var settings = await joinAddressSettings.GetAsync(cancellationToken);
 		if (settings is null)
 		{
-			return Ok(new JoinAddressSettingsDto(null, null, DateTimeOffset.UtcNow.ToString("O")));
+			return Ok(new JoinAddressSettingsDto(null, null, null, null, DateTimeOffset.UtcNow.ToString("O")));
 		}
 
-		return Ok(new JoinAddressSettingsDto(settings.LanHostPort, settings.WanHostPort, settings.UpdatedAtUtc.ToString("O")));
+		return Ok(new JoinAddressSettingsDto(
+			settings.LanHostPort,
+			settings.WanHostPort,
+			settings.RoomLifetimeMinutes,
+			settings.GuestSessionLifetimeMinutes,
+			settings.UpdatedAtUtc.ToString("O")));
 	}
 
 	[HttpPut("join-address")]
@@ -49,14 +54,31 @@ public sealed class AdminController(
 		{
 			lan = NormalizeHostPort(request.LanHostPort, "LanHostPort");
 			wan = NormalizeHostPort(request.WanHostPort, "WanHostPort");
+
+			if (request.RoomLifetimeMinutes is not null && request.RoomLifetimeMinutes <= 0)
+			{
+				throw new ArgumentException("RoomLifetimeMinutes must be null or >= 1.");
+			}
+
+			if (request.GuestSessionLifetimeMinutes is not null && request.GuestSessionLifetimeMinutes <= 0)
+			{
+				throw new ArgumentException("GuestSessionLifetimeMinutes must be null or >= 1.");
+			}
 		}
 		catch (ArgumentException ex)
 		{
 			return BadRequest(ex.Message);
 		}
 
-		var updated = await joinAddressSettings.UpsertAsync(new JoinAddressSettingsUpsert(lan, wan), cancellationToken);
-		return Ok(new JoinAddressSettingsDto(updated.LanHostPort, updated.WanHostPort, updated.UpdatedAtUtc.ToString("O")));
+		var updated = await joinAddressSettings.UpsertAsync(
+			new JoinAddressSettingsUpsert(lan, wan, request.RoomLifetimeMinutes, request.GuestSessionLifetimeMinutes),
+			cancellationToken);
+		return Ok(new JoinAddressSettingsDto(
+			updated.LanHostPort,
+			updated.WanHostPort,
+			updated.RoomLifetimeMinutes,
+			updated.GuestSessionLifetimeMinutes,
+			updated.UpdatedAtUtc.ToString("O")));
 	}
 
 	[HttpGet("casting")]

--- a/src/Tindarr.Api/Controllers/AdminDbController.cs
+++ b/src/Tindarr.Api/Controllers/AdminDbController.cs
@@ -1,0 +1,182 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Tindarr.Api.Auth;
+using Tindarr.Application.Abstractions.Caching;
+using Tindarr.Application.Abstractions.Integrations;
+using Tindarr.Application.Abstractions.Persistence;
+using Tindarr.Application.Options;
+using Tindarr.Contracts.Admin;
+using Tindarr.Contracts.Tmdb;
+using Tindarr.Domain.Common;
+using Tindarr.Infrastructure.Integrations.Tmdb.Http;
+
+namespace Tindarr.Api.Controllers;
+
+[ApiController]
+[Authorize(Policy = Policies.AdminOnly)]
+[Route("api/v1/admin/db")]
+public sealed class AdminDbController(
+	ITmdbMetadataStore tmdbMetadataStore,
+	ITmdbImageCache imageCache,
+	IOptions<TmdbOptions> tmdbOptions,
+	IPlexLibraryCacheRepository plexLibraryCache,
+	ILibraryCacheRepository libraryCache) : ControllerBase
+{
+	[HttpGet("movies")]
+	public async Task<ActionResult<AdminDbMovieListResponse>> ListMovies(
+		[FromQuery] string serviceType,
+		[FromQuery] string serverId,
+		[FromQuery] int skip = 0,
+		[FromQuery] int take = 50,
+		CancellationToken cancellationToken = default)
+	{
+		if (!ServiceScope.TryCreate(serviceType, serverId, out var scope))
+		{
+			return BadRequest("ServiceType and ServerId are required.");
+		}
+
+		skip = Math.Max(0, skip);
+		take = Math.Clamp(take, 1, 200);
+
+		var settings = await tmdbMetadataStore.GetSettingsAsync(cancellationToken).ConfigureAwait(false);
+		var canCheckImages = settings.PosterMode == TmdbPosterMode.LocalProxy && settings.ImageCacheMaxMb > 0;
+		var posterSize = tmdbOptions.Value.PosterSize;
+		var backdropSize = tmdbOptions.Value.BackdropSize;
+
+		if (scope!.ServiceType == ServiceType.Tmdb)
+		{
+			var stats = await tmdbMetadataStore.GetStatsAsync(cancellationToken).ConfigureAwait(false);
+			var chunk = await tmdbMetadataStore.ListMoviesAsync(skip, take, missingDetailsOnly: false, titleQuery: null, cancellationToken).ConfigureAwait(false);
+			var items = new List<TmdbStoredMovieAdminDto>(capacity: chunk.Count);
+			foreach (var m in chunk)
+			{
+				var posterCached = false;
+				var backdropCached = false;
+				if (canCheckImages)
+				{
+					if (!string.IsNullOrWhiteSpace(m.PosterPath))
+					{
+						posterCached = await imageCache.HasAsync(posterSize, m.PosterPath!, cancellationToken).ConfigureAwait(false);
+					}
+					if (!string.IsNullOrWhiteSpace(m.BackdropPath))
+					{
+						backdropCached = await imageCache.HasAsync(backdropSize, m.BackdropPath!, cancellationToken).ConfigureAwait(false);
+					}
+				}
+
+				items.Add(new TmdbStoredMovieAdminDto(
+					TmdbId: m.TmdbId,
+					Title: m.Title,
+					ReleaseYear: m.ReleaseYear,
+					PosterPath: m.PosterPath,
+					BackdropPath: m.BackdropPath,
+					DetailsFetchedAtUtc: m.DetailsFetchedAtUtc,
+					UpdatedAtUtc: m.UpdatedAtUtc,
+					PosterCached: posterCached,
+					BackdropCached: backdropCached));
+			}
+
+			return Ok(new AdminDbMovieListResponse(
+				Items: items,
+				Skip: skip,
+				Take: take,
+				NextSkip: skip + chunk.Count,
+				HasMore: chunk.Count == take,
+				TotalCount: Math.Max(0, stats.MovieCount)));
+		}
+
+		var requested = take + 1;
+		var itemsOut = new List<TmdbStoredMovieAdminDto>(capacity: take);
+		var nextSkip = skip;
+		var hasMore = false;
+		var totalCount = 0;
+
+		if (scope.ServiceType == ServiceType.Plex)
+		{
+			totalCount = await plexLibraryCache.CountTmdbIdsAsync(scope, cancellationToken).ConfigureAwait(false);
+			var cacheChunk = await plexLibraryCache.ListItemsAsync(scope, skip, requested, cancellationToken).ConfigureAwait(false);
+			hasMore = cacheChunk.Count > take;
+			var page = hasMore ? cacheChunk.Take(take) : cacheChunk;
+			nextSkip = skip + page.Count();
+
+			foreach (var entry in page)
+			{
+				var stored = await tmdbMetadataStore.GetMovieAsync(entry.TmdbId, cancellationToken).ConfigureAwait(false);
+				var title = stored?.Title ?? entry.Title;
+
+				var posterCached = false;
+				var backdropCached = false;
+				if (canCheckImages)
+				{
+					if (!string.IsNullOrWhiteSpace(stored?.PosterPath))
+					{
+						posterCached = await imageCache.HasAsync(posterSize, stored!.PosterPath!, cancellationToken).ConfigureAwait(false);
+					}
+					if (!string.IsNullOrWhiteSpace(stored?.BackdropPath))
+					{
+						backdropCached = await imageCache.HasAsync(backdropSize, stored!.BackdropPath!, cancellationToken).ConfigureAwait(false);
+					}
+				}
+
+				itemsOut.Add(new TmdbStoredMovieAdminDto(
+					TmdbId: entry.TmdbId,
+					Title: title,
+					ReleaseYear: stored?.ReleaseYear,
+					PosterPath: stored?.PosterPath,
+					BackdropPath: stored?.BackdropPath,
+					DetailsFetchedAtUtc: stored?.DetailsFetchedAtUtc,
+					UpdatedAtUtc: stored?.UpdatedAtUtc,
+					PosterCached: posterCached,
+					BackdropCached: backdropCached));
+			}
+		}
+		else
+		{
+			totalCount = await libraryCache.CountTmdbIdsAsync(scope, cancellationToken).ConfigureAwait(false);
+			var idsChunk = await libraryCache.ListTmdbIdsAsync(scope, skip, requested, cancellationToken).ConfigureAwait(false);
+			hasMore = idsChunk.Count > take;
+			var page = hasMore ? idsChunk.Take(take) : idsChunk;
+			nextSkip = skip + page.Count();
+
+			foreach (var tmdbId in page)
+			{
+				var stored = await tmdbMetadataStore.GetMovieAsync(tmdbId, cancellationToken).ConfigureAwait(false);
+				var title = stored?.Title ?? $"TMDB #{tmdbId}";
+
+				var posterCached = false;
+				var backdropCached = false;
+				if (canCheckImages)
+				{
+					if (!string.IsNullOrWhiteSpace(stored?.PosterPath))
+					{
+						posterCached = await imageCache.HasAsync(posterSize, stored!.PosterPath!, cancellationToken).ConfigureAwait(false);
+					}
+					if (!string.IsNullOrWhiteSpace(stored?.BackdropPath))
+					{
+						backdropCached = await imageCache.HasAsync(backdropSize, stored!.BackdropPath!, cancellationToken).ConfigureAwait(false);
+					}
+				}
+
+				itemsOut.Add(new TmdbStoredMovieAdminDto(
+					TmdbId: tmdbId,
+					Title: title,
+					ReleaseYear: stored?.ReleaseYear,
+					PosterPath: stored?.PosterPath,
+					BackdropPath: stored?.BackdropPath,
+					DetailsFetchedAtUtc: stored?.DetailsFetchedAtUtc,
+					UpdatedAtUtc: stored?.UpdatedAtUtc,
+					PosterCached: posterCached,
+					BackdropCached: backdropCached));
+			}
+		}
+
+		return Ok(new AdminDbMovieListResponse(
+			Items: itemsOut,
+			Skip: skip,
+			Take: take,
+			NextSkip: nextSkip,
+			HasMore: hasMore,
+			TotalCount: Math.Max(0, totalCount)));
+	}
+}

--- a/src/Tindarr.Api/Controllers/AuthController.cs
+++ b/src/Tindarr.Api/Controllers/AuthController.cs
@@ -17,7 +17,7 @@ public sealed class AuthController(IAuthService authService, ICurrentUser curren
 	{
 		try
 		{
-			var session = await authService.GuestAsync(request.DisplayName, cancellationToken);
+			var session = await authService.GuestAsync(request.RoomId, request.DisplayName, cancellationToken);
 			return Ok(Map(session));
 		}
 		catch (ArgumentException ex)
@@ -70,9 +70,18 @@ public sealed class AuthController(IAuthService authService, ICurrentUser curren
 	}
 
 	[HttpGet("me")]
-	[Authorize]
+	[Authorize(Policy = Tindarr.Api.Auth.Policies.AllowGuests)]
 	public async Task<ActionResult<MeResponse>> Me(CancellationToken cancellationToken)
 	{
+		// Guests are not persisted. For guest sessions, return identity from token claims.
+		if (User.IsInRole(Tindarr.Api.Auth.Policies.GuestRole))
+		{
+			var userId = currentUser.UserId;
+			var displayName = User.FindFirst(Tindarr.Application.Abstractions.Security.TindarrClaimTypes.DisplayName)?.Value
+				?? "Guest";
+			return Ok(new MeResponse(userId, displayName, new[] { Tindarr.Api.Auth.Policies.GuestRole }));
+		}
+
 		var me = await authService.GetMeAsync(currentUser.UserId, cancellationToken);
 		return Ok(new MeResponse(me.UserId, me.DisplayName, me.Roles));
 	}

--- a/src/Tindarr.Api/Controllers/InteractionsController.cs
+++ b/src/Tindarr.Api/Controllers/InteractionsController.cs
@@ -62,9 +62,9 @@ public sealed class InteractionsController(
 			return BadRequest("Radarr is not a swipe scope. Swipe TMDB discover instead.");
 		}
 
-		if (request.Action == SwipeActionDto.Superlike
-			&& !User.IsInRole(Policies.AdminRole)
-			&& !User.IsInRole(Policies.CuratorRole))
+		var isSuperlikePrivileged = User.IsInRole(Policies.AdminRole) || User.IsInRole(Policies.CuratorRole);
+
+		if (request.Action == SwipeActionDto.Superlike && !isSuperlikePrivileged)
 		{
 			return Forbid();
 		}
@@ -73,7 +73,7 @@ public sealed class InteractionsController(
 		var userId = User.GetUserId();
 		var interaction = await interactionService.AddAsync(userId, scope!, request.TmdbId, action, cancellationToken);
 
-		if (scope!.ServiceType == ServiceType.Tmdb && action == InteractionAction.Superlike)
+		if (scope!.ServiceType == ServiceType.Tmdb && action == InteractionAction.Superlike && isSuperlikePrivileged)
 		{
 			var radarrScope = await TryResolveDefaultRadarrScopeAsync(settingsRepo, cancellationToken).ConfigureAwait(false);
 			if (radarrScope is not null)

--- a/src/Tindarr.Api/Controllers/MatchesController.cs
+++ b/src/Tindarr.Api/Controllers/MatchesController.cs
@@ -67,7 +67,20 @@ public sealed class MatchesController(
 		{
 			if (settings.MatchMinUsers is not null)
 			{
-				effectiveMinUsers = Math.Clamp(settings.MatchMinUsers.Value, 0, 50);
+				// MinUsers is validated as 1..50 in AdminController; treat <=0 as legacy/invalid and fall back to defaults.
+				if (settings.MatchMinUsers.Value > 0)
+				{
+					effectiveMinUsers = Math.Clamp(settings.MatchMinUsers.Value, 1, 50);
+				}
+				else if (settings.MatchMinUserPercent is null)
+				{
+					effectiveMinUsers = 2;
+				}
+				else
+				{
+					// Percent-only configuration disables count threshold.
+					effectiveMinUsers = 0;
+				}
 			}
 			else if (settings.MatchMinUserPercent is not null)
 			{

--- a/src/Tindarr.Api/Controllers/RoomsController.cs
+++ b/src/Tindarr.Api/Controllers/RoomsController.cs
@@ -14,7 +14,7 @@ using Tindarr.Domain.Interactions;
 namespace Tindarr.Api.Controllers;
 
 [ApiController]
-[Authorize]
+[Authorize(Policy = Policies.RoomAccess)]
 [Route("api/v1/rooms")]
 public sealed class RoomsController(
 	IRoomService roomService,

--- a/src/Tindarr.Api/Controllers/TmdbController.cs
+++ b/src/Tindarr.Api/Controllers/TmdbController.cs
@@ -225,7 +225,9 @@ public sealed class TmdbController(
 			CurrentMovies: stats.MovieCount,
 			ImageCacheMaxMb: settings.ImageCacheMaxMb,
 			ImageCacheBytes: imageBytes,
-			PosterMode: settings.PosterMode.ToString()));
+			PosterMode: settings.PosterMode.ToString(),
+			PrewarmOriginalLanguage: settings.PrewarmOriginalLanguage,
+			PrewarmRegion: settings.PrewarmRegion));
 	}
 
 	[Authorize(Policy = Policies.AdminOnly)]
@@ -254,11 +256,44 @@ public sealed class TmdbController(
 			return BadRequest("PosterMode must be 'Tmdb' or 'LocalProxy'.");
 		}
 
+		var prewarmLang = string.IsNullOrWhiteSpace(request.PrewarmOriginalLanguage) ? null : request.PrewarmOriginalLanguage.Trim();
+		if (!string.IsNullOrWhiteSpace(prewarmLang))
+		{
+			if (prewarmLang.Length is < 2 or > 10)
+			{
+				return BadRequest("PrewarmOriginalLanguage must be blank or 2-10 characters.");
+			}
+			if (prewarmLang.Any(c => !(char.IsLetter(c) || c == '-' || c == '_')))
+			{
+				return BadRequest("PrewarmOriginalLanguage must contain only letters or '-'/'_'.");
+			}
+		}
+
+		var prewarmRegion = string.IsNullOrWhiteSpace(request.PrewarmRegion) ? null : request.PrewarmRegion.Trim();
+		if (!string.IsNullOrWhiteSpace(prewarmRegion))
+		{
+			if (prewarmRegion.Length is < 2 or > 10)
+			{
+				return BadRequest("PrewarmRegion must be blank or 2-10 characters.");
+			}
+			if (prewarmRegion.Any(c => !(char.IsLetter(c) || c == '-' || c == '_')))
+			{
+				return BadRequest("PrewarmRegion must contain only letters or '-'/'_'.");
+			}
+		}
+
 		await cacheAdmin.SetMaxRowsAsync(request.MaxRows, cancellationToken);
 
 		var current = await metadataStore.GetSettingsAsync(cancellationToken);
 		_ = await metadataStore.SetSettingsAsync(
-			current with { MaxMovies = request.MaxMovies, ImageCacheMaxMb = request.ImageCacheMaxMb, PosterMode = posterMode },
+			current with
+			{
+				MaxMovies = request.MaxMovies,
+				ImageCacheMaxMb = request.ImageCacheMaxMb,
+				PosterMode = posterMode,
+				PrewarmOriginalLanguage = prewarmLang,
+				PrewarmRegion = prewarmRegion
+			},
 			cancellationToken);
 
 		// Apply pruning immediately when lowering the limit.

--- a/src/Tindarr.Api/Program.cs
+++ b/src/Tindarr.Api/Program.cs
@@ -79,6 +79,20 @@ var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 	WebRootPath = webRoot
 });
 
+static string ResolveTmdbMetadataDbPath(IConfiguration config, string? dataDirOverride, IHostEnvironment env)
+{
+	var configuredDbPath = config["Tmdb:MetadataDbPath"];
+	if (!string.IsNullOrWhiteSpace(configuredDbPath))
+	{
+		return Path.IsPathRooted(configuredDbPath)
+			? configuredDbPath
+			: Path.GetFullPath(Path.Combine(dataDirOverride ?? config["Database:DataDir"] ?? env.ContentRootPath, configuredDbPath));
+	}
+
+	var dataRoot = dataDirOverride ?? config["Database:DataDir"] ?? env.ContentRootPath;
+	return Path.Combine(dataRoot, "tmdbmetadata.db");
+}
+
 // Dev + service convenience: allow TMDB_API_KEY (flat env var) to populate Tmdb:ApiKey.
 // ASP.NET Core's default env var mapping expects "Tmdb__ApiKey".
 var tmdbApiKeyEnv = Environment.GetEnvironmentVariable("TMDB_API_KEY");
@@ -233,10 +247,24 @@ builder.Services.AddAuthentication(options =>
 
 builder.Services.AddAuthorization(options =>
 {
+	// Default: authenticated non-guest only.
+	options.DefaultPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
+		.RequireAuthenticatedUser()
+		.RequireAssertion(ctx => !ctx.User.IsInRole(Policies.GuestRole))
+		.Build();
+
 	options.AddPolicy(Policies.AdminOnly, policy => policy.RequireRole(Policies.AdminRole));
 	options.AddPolicy(Policies.CuratorOnly, policy => policy.RequireRole(Policies.CuratorRole));
 	options.AddPolicy(Policies.ContributorOrCurator, policy => policy.RequireRole(Policies.ContributorRole, Policies.CuratorRole, Policies.AdminRole));
+	options.AddPolicy(Policies.AllowGuests, policy => policy.RequireAuthenticatedUser());
+	options.AddPolicy(Policies.RoomAccess, policy =>
+	{
+		policy.RequireAuthenticatedUser();
+		policy.AddRequirements(new Tindarr.Api.Auth.RoomAccessRequirement());
+	});
 });
+
+builder.Services.AddSingleton<Microsoft.AspNetCore.Authorization.IAuthorizationHandler, Tindarr.Api.Auth.RoomAccessAuthorizationHandler>();
 
 builder.Services.AddCors(options =>
 {
@@ -249,6 +277,8 @@ builder.Services.AddCors(options =>
 	});
 });
 
+var tmdbMetadataDbPath = ResolveTmdbMetadataDbPath(builder.Configuration, dataDirOverride, builder.Environment);
+
 builder.Services.AddScoped<EfCoreInteractionStore>();
 builder.Services.AddSingleton<Tindarr.Infrastructure.Interactions.InMemoryInteractionStore>();
 builder.Services.AddScoped<IInteractionStore, Tindarr.Infrastructure.Interactions.RoutingInteractionStore>();
@@ -256,7 +286,6 @@ builder.Services.AddMemoryCache();
 
 // Persist TMDB metadata separately from the main tindarr.db.
 // This avoids repeated upstream TMDB calls across restarts.
-var tmdbMetadataDbPath = Path.Combine(dataDirOverride ?? builder.Environment.ContentRootPath, "tmdbmetadata.db");
 builder.Services.AddSingleton<ITmdbCache>(sp =>
 	new MemoryOrDbTmdbCache(sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>(), tmdbMetadataDbPath));
 builder.Services.AddSingleton<ITmdbCacheAdmin>(sp => (ITmdbCacheAdmin)sp.GetRequiredService<ITmdbCache>());
@@ -316,6 +345,7 @@ builder.Services.AddScoped<IMatchingEngine, MatchingEngine>();
 
 builder.Services.AddSingleton<Tindarr.Application.Interfaces.Rooms.IRoomStore, Tindarr.Infrastructure.Rooms.InMemoryRoomStore>();
 builder.Services.AddSingleton<Tindarr.Application.Interfaces.Rooms.IRoomInteractionStore, Tindarr.Infrastructure.Rooms.InMemoryRoomInteractionStore>();
+builder.Services.AddSingleton<Tindarr.Application.Interfaces.Rooms.IRoomLifetimeProvider, Tindarr.Infrastructure.Rooms.RoomLifetimeProvider>();
 builder.Services.AddScoped<Tindarr.Application.Interfaces.Rooms.IRoomService, Tindarr.Application.Features.Rooms.RoomService>();
 
 // Keep DB location stable across Debug/Release so migrations and runtime match.

--- a/src/Tindarr.Api/Services/TmdbBuildJob.cs
+++ b/src/Tindarr.Api/Services/TmdbBuildJob.cs
@@ -97,6 +97,7 @@ public sealed class TmdbBuildJob(
 				&& settings.PosterMode == TmdbPosterMode.LocalProxy
 				&& settings.ImageCacheMaxMb > 0;
 			var maxImageBytes = (long)Math.Max(0, settings.ImageCacheMaxMb) * 1024L * 1024L;
+			var discoveredIds = new HashSet<int>();
 
 			var bypass = request.RateLimitOverride;
 			var previousBypass = TmdbRateLimitingHandler.BypassRateLimit.Value;
@@ -112,36 +113,30 @@ public sealed class TmdbBuildJob(
 						Update(s => s with { CurrentUserId = user.Id, LastMessage = "Discovering" });
 
 						var prefs = await prefsService.GetOrDefaultAsync(user.Id, stoppingToken).ConfigureAwait(false);
-						var discovered = await tmdbClient.DiscoverMoviesAsync(prefs, page: 1, limit: discoverLimit, stoppingToken).ConfigureAwait(false);
-						await metadataStore.AddToUserPoolAsync(user.Id, discovered, stoppingToken).ConfigureAwait(false);
+						var effectivePrefs = prefs;
+						if (!string.IsNullOrWhiteSpace(settings.PrewarmOriginalLanguage))
+						{
+							effectivePrefs = effectivePrefs with
+							{
+								PreferredOriginalLanguages = new[] { settings.PrewarmOriginalLanguage }
+							};
+						}
+						if (!string.IsNullOrWhiteSpace(settings.PrewarmRegion))
+						{
+							effectivePrefs = effectivePrefs with
+							{
+								PreferredRegions = new[] { settings.PrewarmRegion }
+							};
+						}
+
+						var discovered = await tmdbClient.DiscoverMoviesAsync(effectivePrefs, page: 1, limit: discoverLimit, stoppingToken).ConfigureAwait(false);
+						await metadataStore.UpsertMoviesAsync(discovered, stoppingToken).ConfigureAwait(false);
+						foreach (var m in discovered)
+						{
+							discoveredIds.Add(m.Id);
+						}
 
 						Update(s => s with { MoviesDiscovered = s.MoviesDiscovered + discovered.Count });
-
-						if (shouldPrefetchImages)
-						{
-							Update(s => s with { LastMessage = "Prefetching images" });
-							foreach (var m in discovered.Take(12))
-							{
-								stoppingToken.ThrowIfCancellationRequested();
-								var fetchedAny = false;
-								if (!string.IsNullOrWhiteSpace(m.PosterPath))
-								{
-									var r = await imageCache.GetOrFetchAsync(tmdb.PosterSize, m.PosterPath!, stoppingToken).ConfigureAwait(false);
-									fetchedAny |= r is not null;
-								}
-								if (!string.IsNullOrWhiteSpace(m.BackdropPath))
-								{
-									var r = await imageCache.GetOrFetchAsync(tmdb.BackdropSize, m.BackdropPath!, stoppingToken).ConfigureAwait(false);
-									fetchedAny |= r is not null;
-								}
-								if (fetchedAny)
-								{
-									Update(s => s with { ImagesFetched = s.ImagesFetched + 1 });
-								}
-							}
-
-							await imageCache.PruneAsync(maxImageBytes, stoppingToken).ConfigureAwait(false);
-						}
 
 						processed++;
 						Update(s => s with { UsersProcessed = processed, LastMessage = "User complete" });
@@ -153,12 +148,16 @@ public sealed class TmdbBuildJob(
 				TmdbRateLimitingHandler.BypassRateLimit.Value = previousBypass;
 			}
 
-			// Backfill a bit of details at the end (genres/etc).
+			// Backfill details for ALL discovered movies.
 			Update(s => s with { LastMessage = "Backfilling details" });
-			var ids = await metadataStore.ListMoviesNeedingDetailsAsync(50, stoppingToken).ConfigureAwait(false);
-			foreach (var id in ids)
+			foreach (var id in discoveredIds)
 			{
 				stoppingToken.ThrowIfCancellationRequested();
+				var existing = await metadataStore.GetMovieAsync(id, stoppingToken).ConfigureAwait(false);
+				if (existing?.DetailsFetchedAtUtc is not null)
+				{
+					continue;
+				}
 				var details = await tmdbClient.GetMovieDetailsAsync(id, stoppingToken).ConfigureAwait(false);
 				if (details is null)
 				{
@@ -166,6 +165,46 @@ public sealed class TmdbBuildJob(
 				}
 				await metadataStore.UpdateMovieDetailsAsync(details, stoppingToken).ConfigureAwait(false);
 				Update(s => s with { DetailsFetched = s.DetailsFetched + 1 });
+			}
+
+			// Cache images for ALL discovered movies (best-effort) when using LocalProxy.
+			if (shouldPrefetchImages)
+			{
+				Update(s => s with { LastMessage = "Fetching images" });
+				var iter = 0;
+				foreach (var id in discoveredIds)
+				{
+					stoppingToken.ThrowIfCancellationRequested();
+					var movie = await metadataStore.GetMovieAsync(id, stoppingToken).ConfigureAwait(false);
+					if (movie is null)
+					{
+						continue;
+					}
+
+					var fetchedAny = false;
+					if (!string.IsNullOrWhiteSpace(movie.PosterPath))
+					{
+						var r = await imageCache.GetOrFetchAsync(tmdb.PosterSize, movie.PosterPath!, stoppingToken).ConfigureAwait(false);
+						fetchedAny |= r is not null;
+					}
+					if (!string.IsNullOrWhiteSpace(movie.BackdropPath))
+					{
+						var r = await imageCache.GetOrFetchAsync(tmdb.BackdropSize, movie.BackdropPath!, stoppingToken).ConfigureAwait(false);
+						fetchedAny |= r is not null;
+					}
+					if (fetchedAny)
+					{
+						Update(s => s with { ImagesFetched = s.ImagesFetched + 1 });
+					}
+
+					iter++;
+					if (iter % 200 == 0)
+					{
+						await imageCache.PruneAsync(maxImageBytes, stoppingToken).ConfigureAwait(false);
+					}
+				}
+
+				await imageCache.PruneAsync(maxImageBytes, stoppingToken).ConfigureAwait(false);
 			}
 
 			Update(s => s.Complete("Done"));

--- a/src/Tindarr.Application/Abstractions/Integrations/ITmdbMetadataStore.cs
+++ b/src/Tindarr.Application/Abstractions/Integrations/ITmdbMetadataStore.cs
@@ -12,7 +12,9 @@ public sealed record TmdbMetadataSettings(
 	int MaxMovies,
 	int MaxPoolPerUser,
 	int ImageCacheMaxMb,
-	TmdbPosterMode PosterMode);
+	TmdbPosterMode PosterMode,
+	string? PrewarmOriginalLanguage,
+	string? PrewarmRegion);
 
 public sealed record TmdbMetadataStats(int MovieCount, long ImageCacheBytes);
 
@@ -55,6 +57,8 @@ public interface ITmdbMetadataStore
 	Task UpdateMovieDetailsAsync(MovieDetailsDto details, CancellationToken cancellationToken);
 
 	Task<TmdbStoredMovie?> GetMovieAsync(int tmdbId, CancellationToken cancellationToken);
+
+	Task<IReadOnlyList<TmdbDiscoverMovieRecord>> ListDeckCandidatesAsync(int take, CancellationToken cancellationToken);
 
 	Task<IReadOnlyList<TmdbStoredMovie>> ListMoviesAsync(int skip, int take, bool missingDetailsOnly, string? titleQuery, CancellationToken cancellationToken);
 }

--- a/src/Tindarr.Application/Abstractions/Persistence/IJoinAddressSettingsRepository.cs
+++ b/src/Tindarr.Application/Abstractions/Persistence/IJoinAddressSettingsRepository.cs
@@ -10,8 +10,12 @@ public interface IJoinAddressSettingsRepository
 public sealed record JoinAddressSettingsRecord(
 	string? LanHostPort,
 	string? WanHostPort,
+	int? RoomLifetimeMinutes,
+	int? GuestSessionLifetimeMinutes,
 	DateTimeOffset UpdatedAtUtc);
 
 public sealed record JoinAddressSettingsUpsert(
 	string? LanHostPort,
-	string? WanHostPort);
+	string? WanHostPort,
+	int? RoomLifetimeMinutes,
+	int? GuestSessionLifetimeMinutes);

--- a/src/Tindarr.Application/Abstractions/Persistence/ILibraryCacheRepository.cs
+++ b/src/Tindarr.Application/Abstractions/Persistence/ILibraryCacheRepository.cs
@@ -6,6 +6,10 @@ public interface ILibraryCacheRepository
 {
 	Task<IReadOnlyCollection<int>> GetTmdbIdsAsync(ServiceScope scope, CancellationToken cancellationToken);
 
+	Task<IReadOnlyList<int>> ListTmdbIdsAsync(ServiceScope scope, int skip, int take, CancellationToken cancellationToken);
+
+	Task<int> CountTmdbIdsAsync(ServiceScope scope, CancellationToken cancellationToken);
+
 	Task ReplaceTmdbIdsAsync(ServiceScope scope, IReadOnlyCollection<int> tmdbIds, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken);
 
 	Task AddTmdbIdsAsync(ServiceScope scope, IReadOnlyCollection<int> tmdbIds, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken);

--- a/src/Tindarr.Application/Abstractions/Persistence/IPlexLibraryCacheRepository.cs
+++ b/src/Tindarr.Application/Abstractions/Persistence/IPlexLibraryCacheRepository.cs
@@ -7,6 +7,8 @@ public interface IPlexLibraryCacheRepository
 {
 	Task<IReadOnlyCollection<int>> GetTmdbIdsAsync(ServiceScope scope, CancellationToken cancellationToken);
 
+	Task<int> CountTmdbIdsAsync(ServiceScope scope, CancellationToken cancellationToken);
+
 	Task<IReadOnlyList<PlexLibraryItem>> ListItemsAsync(ServiceScope scope, int skip, int take, CancellationToken cancellationToken);
 
 	Task<string?> TryGetRatingKeyAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken);

--- a/src/Tindarr.Application/Abstractions/Persistence/IRadarrPendingAddRepository.cs
+++ b/src/Tindarr.Application/Abstractions/Persistence/IRadarrPendingAddRepository.cs
@@ -4,6 +4,12 @@ namespace Tindarr.Application.Abstractions.Persistence;
 
 public interface IRadarrPendingAddRepository
 {
+	/// <summary>
+	/// Returns the next scheduled ReadyAtUtc timestamp for any pending (not canceled, not processed)
+	/// record, or null if no pending records exist.
+	/// </summary>
+	Task<DateTimeOffset?> GetNextReadyAtUtcAsync(CancellationToken cancellationToken);
+
 	Task<bool> TryEnqueueAsync(
 		ServiceScope scope,
 		string userId,

--- a/src/Tindarr.Application/Abstractions/Security/ITokenService.cs
+++ b/src/Tindarr.Application/Abstractions/Security/ITokenService.cs
@@ -1,9 +1,22 @@
+using System.Security.Claims;
+
 namespace Tindarr.Application.Abstractions.Security;
 
 public interface ITokenService
 {
-	TokenResult IssueAccessToken(string userId, IReadOnlyCollection<string> roles);
+	TokenResult IssueAccessToken(
+		string userId,
+		IReadOnlyCollection<string> roles,
+		IReadOnlyCollection<Claim>? additionalClaims = null,
+		TimeSpan? lifetimeOverride = null);
 }
 
 public sealed record TokenResult(string AccessToken, DateTimeOffset ExpiresAtUtc);
+
+public static class TindarrClaimTypes
+{
+	public const string RoomId = "tindarr:roomId";
+	public const string DisplayName = "tindarr:displayName";
+	public const string IsGuest = "tindarr:isGuest";
+}
 

--- a/src/Tindarr.Application/Features/Auth/AuthService.cs
+++ b/src/Tindarr.Application/Features/Auth/AuthService.cs
@@ -1,7 +1,9 @@
 using Tindarr.Application.Abstractions.Persistence;
 using Tindarr.Application.Abstractions.Security;
 using Tindarr.Application.Interfaces.Auth;
+using Tindarr.Application.Interfaces.Rooms;
 using Tindarr.Application.Options;
+using System.Security.Claims;
 
 namespace Tindarr.Application.Features.Auth;
 
@@ -9,33 +11,47 @@ public sealed class AuthService(
 	IUserRepository users,
 	IPasswordHasher passwordHasher,
 	ITokenService tokenService,
+	IRoomService roomService,
+	IRoomLifetimeProvider roomLifetimeProvider,
 	Microsoft.Extensions.Options.IOptions<RegistrationOptions> registrationOptions) : IAuthService
 {
 	private readonly RegistrationOptions registration = registrationOptions.Value;
 
-	public async Task<AuthSession> GuestAsync(string? displayName, CancellationToken cancellationToken)
+	public async Task<AuthSession> GuestAsync(string roomId, string? displayName, CancellationToken cancellationToken)
 	{
-		var normalizedDisplayName = string.IsNullOrWhiteSpace(displayName) ? "Guest" : NormalizeDisplayName(displayName);
-		var now = DateTimeOffset.UtcNow;
-
-		// Try a handful of times to avoid collisions.
-		for (var attempt = 0; attempt < 10; attempt++)
+		if (string.IsNullOrWhiteSpace(roomId))
 		{
-			var id = $"guest-{Guid.NewGuid():N}";
-			if (await users.UserExistsAsync(id, cancellationToken))
-			{
-				continue;
-			}
-
-			await users.CreateAsync(new CreateUserRecord(id, normalizedDisplayName, now), cancellationToken);
-			await users.SetRolesAsync(id, new[] { registration.DefaultRole }, cancellationToken);
-
-			var roles = await users.GetRolesAsync(id, cancellationToken);
-			var token = tokenService.IssueAccessToken(id, roles.ToList());
-			return new AuthSession(token.AccessToken, token.ExpiresAtUtc, id, normalizedDisplayName, roles.ToList());
+			throw new ArgumentException("RoomId is required.");
 		}
 
-		throw new InvalidOperationException("Could not create guest session.");
+		var room = await roomService.GetAsync(roomId, cancellationToken);
+		if (room is null)
+		{
+			throw new InvalidOperationException("Room not found.");
+		}
+
+		if (room.IsClosed)
+		{
+			throw new InvalidOperationException("Room is closed to new users.");
+		}
+
+		var normalizedDisplayName = string.IsNullOrWhiteSpace(displayName) ? "Guest" : NormalizeDisplayName(displayName);
+		var id = $"guest-{Guid.NewGuid():N}";
+
+		var roles = new List<string> { "Guest" };
+		var ttl = await roomLifetimeProvider.GetGuestSessionTtlAsync(cancellationToken).ConfigureAwait(false);
+		var token = tokenService.IssueAccessToken(
+			id,
+			roles,
+			additionalClaims: new[]
+			{
+				new Claim(TindarrClaimTypes.IsGuest, "1"),
+				new Claim(TindarrClaimTypes.RoomId, room.RoomId),
+				new Claim(TindarrClaimTypes.DisplayName, normalizedDisplayName)
+			},
+			lifetimeOverride: ttl);
+
+		return new AuthSession(token.AccessToken, token.ExpiresAtUtc, id, normalizedDisplayName, roles);
 	}
 
 	public async Task<AuthSession> RegisterAsync(string userId, string displayName, string password, CancellationToken cancellationToken)

--- a/src/Tindarr.Application/Interfaces/Auth/IAuthService.cs
+++ b/src/Tindarr.Application/Interfaces/Auth/IAuthService.cs
@@ -8,7 +8,7 @@ public interface IAuthService
 
 	Task<AuthSession> LoginAsync(string userId, string password, CancellationToken cancellationToken);
 
-	Task<AuthSession> GuestAsync(string? displayName, CancellationToken cancellationToken);
+	Task<AuthSession> GuestAsync(string roomId, string? displayName, CancellationToken cancellationToken);
 
 	Task<AuthUserInfo> GetMeAsync(string userId, CancellationToken cancellationToken);
 

--- a/src/Tindarr.Application/Interfaces/Rooms/IRoomLifetimeProvider.cs
+++ b/src/Tindarr.Application/Interfaces/Rooms/IRoomLifetimeProvider.cs
@@ -1,0 +1,7 @@
+namespace Tindarr.Application.Interfaces.Rooms;
+
+public interface IRoomLifetimeProvider
+{
+	Task<TimeSpan> GetRoomTtlAsync(CancellationToken cancellationToken);
+	Task<TimeSpan> GetGuestSessionTtlAsync(CancellationToken cancellationToken);
+}

--- a/src/Tindarr.Contracts/Admin/AdminDbMovieListResponse.cs
+++ b/src/Tindarr.Contracts/Admin/AdminDbMovieListResponse.cs
@@ -1,0 +1,11 @@
+using Tindarr.Contracts.Tmdb;
+
+namespace Tindarr.Contracts.Admin;
+
+public sealed record AdminDbMovieListResponse(
+	IReadOnlyList<TmdbStoredMovieAdminDto> Items,
+	int Skip,
+	int Take,
+	int NextSkip,
+	bool HasMore,
+	int TotalCount);

--- a/src/Tindarr.Contracts/Admin/JoinAddressSettingsDto.cs
+++ b/src/Tindarr.Contracts/Admin/JoinAddressSettingsDto.cs
@@ -3,4 +3,6 @@ namespace Tindarr.Contracts.Admin;
 public sealed record JoinAddressSettingsDto(
 	string? LanHostPort,
 	string? WanHostPort,
+	int? RoomLifetimeMinutes,
+	int? GuestSessionLifetimeMinutes,
 	string UpdatedAtUtc);

--- a/src/Tindarr.Contracts/Admin/UpdateJoinAddressSettingsRequest.cs
+++ b/src/Tindarr.Contracts/Admin/UpdateJoinAddressSettingsRequest.cs
@@ -2,4 +2,6 @@ namespace Tindarr.Contracts.Admin;
 
 public sealed record UpdateJoinAddressSettingsRequest(
 	string? LanHostPort,
-	string? WanHostPort);
+	string? WanHostPort,
+	int? RoomLifetimeMinutes,
+	int? GuestSessionLifetimeMinutes);

--- a/src/Tindarr.Contracts/Auth/GuestLoginRequest.cs
+++ b/src/Tindarr.Contracts/Auth/GuestLoginRequest.cs
@@ -1,3 +1,3 @@
 namespace Tindarr.Contracts.Auth;
 
-public sealed record GuestLoginRequest(string? DisplayName);
+public sealed record GuestLoginRequest(string RoomId, string? DisplayName);

--- a/src/Tindarr.Contracts/Tmdb/TmdbCacheSettingsDto.cs
+++ b/src/Tindarr.Contracts/Tmdb/TmdbCacheSettingsDto.cs
@@ -7,4 +7,6 @@ public sealed record TmdbCacheSettingsDto(
 	int CurrentMovies,
 	int ImageCacheMaxMb,
 	long ImageCacheBytes,
-	string PosterMode);
+	string PosterMode,
+	string? PrewarmOriginalLanguage,
+	string? PrewarmRegion);

--- a/src/Tindarr.Contracts/Tmdb/UpdateTmdbCacheSettingsRequest.cs
+++ b/src/Tindarr.Contracts/Tmdb/UpdateTmdbCacheSettingsRequest.cs
@@ -4,4 +4,6 @@ public sealed record UpdateTmdbCacheSettingsRequest(
 	int MaxRows,
 	int MaxMovies,
 	int ImageCacheMaxMb,
-	string PosterMode);
+	string PosterMode,
+	string? PrewarmOriginalLanguage,
+	string? PrewarmRegion);

--- a/src/Tindarr.Infrastructure/Integrations/Tmdb/TmdbMetadataStore.cs
+++ b/src/Tindarr.Infrastructure/Integrations/Tmdb/TmdbMetadataStore.cs
@@ -23,6 +23,8 @@ public sealed class TmdbMetadataStore(string sqliteDbPath) : ITmdbMetadataStore
 	private const string SettingsKeyMaxPoolPerUser = "pool_max_per_user";
 	private const string SettingsKeyImageCacheMaxMb = "image_cache_max_mb";
 	private const string SettingsKeyPosterMode = "poster_mode";
+	private const string SettingsKeyPrewarmOriginalLanguage = "prewarm_original_language";
+	private const string SettingsKeyPrewarmRegion = "prewarm_region";
 
 	private const int DefaultMaxMovies = 20_000;
 	private const int MinMaxMovies = 500;
@@ -37,6 +39,9 @@ public sealed class TmdbMetadataStore(string sqliteDbPath) : ITmdbMetadataStore
 	private const int MaxImageCacheMaxMb = 100_000;
 
 	private const TmdbPosterMode DefaultPosterMode = TmdbPosterMode.Tmdb;
+
+	private const string? DefaultPrewarmOriginalLanguage = null;
+	private const string? DefaultPrewarmRegion = null;
 
 	private SqliteConnection CreateConnection()
 	{
@@ -172,6 +177,8 @@ public sealed class TmdbMetadataStore(string sqliteDbPath) : ITmdbMetadataStore
 			await SeedDefaultSettingAsync(conn, SettingsKeyMaxPoolPerUser, DefaultMaxPoolPerUser.ToString(), cancellationToken).ConfigureAwait(false);
 			await SeedDefaultSettingAsync(conn, SettingsKeyImageCacheMaxMb, DefaultImageCacheMaxMb.ToString(), cancellationToken).ConfigureAwait(false);
 			await SeedDefaultSettingAsync(conn, SettingsKeyPosterMode, DefaultPosterMode.ToString(), cancellationToken).ConfigureAwait(false);
+			await SeedDefaultSettingAsync(conn, SettingsKeyPrewarmOriginalLanguage, DefaultPrewarmOriginalLanguage ?? string.Empty, cancellationToken).ConfigureAwait(false);
+			await SeedDefaultSettingAsync(conn, SettingsKeyPrewarmRegion, DefaultPrewarmRegion ?? string.Empty, cancellationToken).ConfigureAwait(false);
 
 			_initialized = true;
 		}
@@ -218,6 +225,40 @@ public sealed class TmdbMetadataStore(string sqliteDbPath) : ITmdbMetadataStore
 		}
 
 		return Enum.TryParse<TmdbPosterMode>(raw, ignoreCase: true, out var parsed) ? parsed : DefaultPosterMode;
+	}
+
+	private static string? NormalizeLanguage(string? raw)
+	{
+		var v = (raw ?? string.Empty).Trim();
+		if (string.IsNullOrWhiteSpace(v))
+		{
+			return null;
+		}
+
+		if (v.Length > 10)
+		{
+			v = v[..10];
+		}
+
+		// TMDB expects e.g. "en".
+		return v.ToLowerInvariant();
+	}
+
+	private static string? NormalizeRegion(string? raw)
+	{
+		var v = (raw ?? string.Empty).Trim();
+		if (string.IsNullOrWhiteSpace(v))
+		{
+			return null;
+		}
+
+		if (v.Length > 10)
+		{
+			v = v[..10];
+		}
+
+		// TMDB expects ISO-3166-1 like "US".
+		return v.ToUpperInvariant();
 	}
 
 	private static async ValueTask<string?> GetSettingRawAsync(SqliteConnection conn, string key, CancellationToken cancellationToken)
@@ -287,8 +328,10 @@ public sealed class TmdbMetadataStore(string sqliteDbPath) : ITmdbMetadataStore
 			DefaultImageCacheMaxMb);
 
 		var posterMode = ParsePosterMode(await GetSettingRawAsync(conn, SettingsKeyPosterMode, cancellationToken));
+		var prewarmOriginalLanguage = NormalizeLanguage(await GetSettingRawAsync(conn, SettingsKeyPrewarmOriginalLanguage, cancellationToken));
+		var prewarmRegion = NormalizeRegion(await GetSettingRawAsync(conn, SettingsKeyPrewarmRegion, cancellationToken));
 
-		return new TmdbMetadataSettings(maxMovies, maxPool, maxMb, posterMode);
+		return new TmdbMetadataSettings(maxMovies, maxPool, maxMb, posterMode, prewarmOriginalLanguage, prewarmRegion);
 	}
 
 	public async ValueTask<TmdbMetadataSettings> SetSettingsAsync(TmdbMetadataSettings settings, CancellationToken cancellationToken)
@@ -299,7 +342,9 @@ public sealed class TmdbMetadataStore(string sqliteDbPath) : ITmdbMetadataStore
 			MaxMovies: Clamp(settings.MaxMovies, MinMaxMovies, MaxMaxMovies, DefaultMaxMovies),
 			MaxPoolPerUser: Clamp(settings.MaxPoolPerUser, MinMaxPoolPerUser, MaxMaxPoolPerUser, DefaultMaxPoolPerUser),
 			ImageCacheMaxMb: Clamp(settings.ImageCacheMaxMb, MinImageCacheMaxMb, MaxImageCacheMaxMb, DefaultImageCacheMaxMb),
-			PosterMode: settings.PosterMode);
+			PosterMode: settings.PosterMode,
+			PrewarmOriginalLanguage: NormalizeLanguage(settings.PrewarmOriginalLanguage),
+			PrewarmRegion: NormalizeRegion(settings.PrewarmRegion));
 
 		await using var conn = CreateConnection();
 		await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
@@ -309,6 +354,8 @@ public sealed class TmdbMetadataStore(string sqliteDbPath) : ITmdbMetadataStore
 		await SetSettingRawAsync(conn, SettingsKeyMaxPoolPerUser, normalized.MaxPoolPerUser.ToString(), cancellationToken).ConfigureAwait(false);
 		await SetSettingRawAsync(conn, SettingsKeyImageCacheMaxMb, normalized.ImageCacheMaxMb.ToString(), cancellationToken).ConfigureAwait(false);
 		await SetSettingRawAsync(conn, SettingsKeyPosterMode, normalized.PosterMode.ToString(), cancellationToken).ConfigureAwait(false);
+		await SetSettingRawAsync(conn, SettingsKeyPrewarmOriginalLanguage, normalized.PrewarmOriginalLanguage ?? string.Empty, cancellationToken).ConfigureAwait(false);
+		await SetSettingRawAsync(conn, SettingsKeyPrewarmRegion, normalized.PrewarmRegion ?? string.Empty, cancellationToken).ConfigureAwait(false);
 
 		await MaybeRunMaintenanceAsync(conn, cancellationToken).ConfigureAwait(false);
 		return normalized;
@@ -798,6 +845,77 @@ public sealed class TmdbMetadataStore(string sqliteDbPath) : ITmdbMetadataStore
 			RuntimeMinutes: runtimeMinutes,
 			DetailsFetchedAtUtc: detailsFetchedAt,
 			UpdatedAtUtc: updatedAt);
+	}
+
+	public async Task<IReadOnlyList<TmdbDiscoverMovieRecord>> ListDeckCandidatesAsync(int take, CancellationToken cancellationToken)
+	{
+		await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+		take = Math.Clamp(take, 1, 5_000);
+
+		await using var conn = CreateConnection();
+		await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+		await ApplyConnectionPragmasAsync(conn, cancellationToken).ConfigureAwait(false);
+
+		var cmd = conn.CreateCommand();
+		cmd.CommandText = """
+			SELECT
+				tmdb_id,
+				title,
+				original_title,
+				overview,
+				poster_path,
+				backdrop_path,
+				release_date,
+				original_language,
+				rating,
+				genre_ids_json
+			FROM tmdb_movies
+			ORDER BY updated_at_utc DESC
+			LIMIT $take;
+		""";
+		cmd.Parameters.AddWithValue("$take", take);
+
+		var results = new List<TmdbDiscoverMovieRecord>(capacity: take);
+		await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+		while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+		{
+			var tmdbId = reader.GetInt32(0);
+			var title = reader.IsDBNull(1) ? null : reader.GetString(1);
+			var originalTitle = reader.IsDBNull(2) ? null : reader.GetString(2);
+			var overview = reader.IsDBNull(3) ? null : reader.GetString(3);
+			var posterPath = reader.IsDBNull(4) ? null : reader.GetString(4);
+			var backdropPath = reader.IsDBNull(5) ? null : reader.GetString(5);
+			var releaseDate = reader.IsDBNull(6) ? null : reader.GetString(6);
+			var originalLanguage = reader.IsDBNull(7) ? null : reader.GetString(7);
+			double? rating = reader.IsDBNull(8) ? null : reader.GetDouble(8);
+			var genreIdsJson = reader.IsDBNull(9) ? null : reader.GetString(9);
+			IReadOnlyList<int>? genreIds = null;
+			if (!string.IsNullOrWhiteSpace(genreIdsJson))
+			{
+				try
+				{
+					genreIds = JsonSerializer.Deserialize<IReadOnlyList<int>>(genreIdsJson, Json);
+				}
+				catch
+				{
+					genreIds = null;
+				}
+			}
+
+			results.Add(new TmdbDiscoverMovieRecord(
+				Id: tmdbId,
+				Title: title,
+				OriginalTitle: originalTitle,
+				Overview: overview,
+				PosterPath: posterPath,
+				BackdropPath: backdropPath,
+				ReleaseDate: releaseDate,
+				OriginalLanguage: originalLanguage,
+				VoteAverage: rating,
+				GenreIds: genreIds));
+		}
+
+		return results;
 	}
 
 	public async Task<IReadOnlyList<TmdbStoredMovie>> ListMoviesAsync(

--- a/src/Tindarr.Infrastructure/Integrations/Tmdb/TmdbSwipeDeckSource.cs
+++ b/src/Tindarr.Infrastructure/Integrations/Tmdb/TmdbSwipeDeckSource.cs
@@ -1,4 +1,5 @@
 using Tindarr.Application.Abstractions.Integrations;
+using Tindarr.Application.Abstractions.Persistence;
 using Tindarr.Application.Interfaces.Interactions;
 using Tindarr.Application.Interfaces.Preferences;
 using Tindarr.Application.Options;
@@ -28,19 +29,21 @@ public sealed class TmdbSwipeDeckSource(
 		var sw = Stopwatch.StartNew();
 		var prefs = await preferencesService.GetOrDefaultAsync(userId, cancellationToken).ConfigureAwait(false);
 
-		// Prefer local pool for near-instant decks.
+		// Use the shared metadata pool and filter by current prefs at deck build time.
 		var settings = await metadataStore.GetSettingsAsync(cancellationToken).ConfigureAwait(false);
-		var pool = await metadataStore.GetUserPoolAsync(userId, limit: 50, cancellationToken).ConfigureAwait(false);
+		var pool = await metadataStore.ListDeckCandidatesAsync(take: 1_000, cancellationToken).ConfigureAwait(false);
+		var filteredPool = pool.Where(m => MatchesPreferencesLoosely(m, prefs)).ToList();
 
-		// If pool is low, backfill it from TMDB discover (background jobs should usually keep it full).
-		if (pool.Count < 25)
+		// If the filtered pool is low, pull more from TMDB Discover for this user's prefs and upsert into the shared store.
+		if (filteredPool.Count < 25)
 		{
-			var discovered = await tmdbClient.DiscoverMoviesAsync(prefs, page: 1, limit: 50, cancellationToken).ConfigureAwait(false);
-			await metadataStore.AddToUserPoolAsync(userId, discovered, cancellationToken).ConfigureAwait(false);
-			pool = await metadataStore.GetUserPoolAsync(userId, limit: 50, cancellationToken).ConfigureAwait(false);
+			var discovered = await tmdbClient.DiscoverMoviesAsync(prefs, page: 1, limit: 200, cancellationToken).ConfigureAwait(false);
+			await metadataStore.UpsertMoviesAsync(discovered, cancellationToken).ConfigureAwait(false);
+			pool = await metadataStore.ListDeckCandidatesAsync(take: 1_000, cancellationToken).ConfigureAwait(false);
+			filteredPool = pool.Where(m => MatchesPreferencesLoosely(m, prefs)).ToList();
 		}
 
-		var cards = pool.Select(m => new SwipeCard(
+		var cards = filteredPool.Take(200).Select(m => new SwipeCard(
 			TmdbId: m.Id,
 			Title: (m.Title ?? m.OriginalTitle ?? $"TMDB:{m.Id}").Trim(),
 			Overview: m.Overview,
@@ -52,13 +55,72 @@ public sealed class TmdbSwipeDeckSource(
 		sw.Stop();
 		logger.LogDebug(
 			"tmdb deck source produced candidates. Source={Source} ServiceType={ServiceType} ServerId={ServerId} Count={Count} ElapsedMs={ElapsedMs}",
-			"local_pool",
+			"shared_pool",
 			scope.ServiceType.ToString().ToLowerInvariant(),
 			scope.ServerId,
 			cards.Count,
 			sw.ElapsedMilliseconds);
 
 		return cards;
+	}
+
+	private static bool MatchesPreferencesLoosely(TmdbDiscoverMovieRecord movie, UserPreferencesRecord preferences)
+	{
+		var year = TryParseYear(movie.ReleaseDate);
+		if (preferences.MinReleaseYear is not null && year is not null && year < preferences.MinReleaseYear)
+		{
+			return false;
+		}
+		if (preferences.MaxReleaseYear is not null && year is not null && year > preferences.MaxReleaseYear)
+		{
+			return false;
+		}
+
+		if (preferences.MinRating is not null && movie.VoteAverage is not null && movie.VoteAverage < preferences.MinRating)
+		{
+			return false;
+		}
+		if (preferences.MaxRating is not null && movie.VoteAverage is not null && movie.VoteAverage > preferences.MaxRating)
+		{
+			return false;
+		}
+
+		if (preferences.PreferredOriginalLanguages is { Count: > 0 })
+		{
+			if (!string.IsNullOrWhiteSpace(movie.OriginalLanguage)
+				&& !preferences.PreferredOriginalLanguages.Contains(movie.OriginalLanguage, StringComparer.OrdinalIgnoreCase))
+			{
+				return false;
+			}
+		}
+
+		if (preferences.ExcludedOriginalLanguages is { Count: > 0 } && !string.IsNullOrWhiteSpace(movie.OriginalLanguage))
+		{
+			if (preferences.ExcludedOriginalLanguages.Contains(movie.OriginalLanguage, StringComparer.OrdinalIgnoreCase))
+			{
+				return false;
+			}
+		}
+
+		if (preferences.PreferredGenres is { Count: > 0 } && movie.GenreIds is { Count: > 0 })
+		{
+			if (!preferences.PreferredGenres.Any(g => movie.GenreIds.Contains(g)))
+			{
+				return false;
+			}
+		}
+
+		if (preferences.ExcludedGenres is { Count: > 0 } && movie.GenreIds is { Count: > 0 })
+		{
+			if (preferences.ExcludedGenres.Any(g => movie.GenreIds.Contains(g)))
+			{
+				return false;
+			}
+		}
+
+		// Regions require details-derived data; the discover record doesn't include regions.
+		// Keep this loose to avoid filtering out movies until details are available.
+		return true;
 	}
 
 	private static string? BuildImageUrl(TmdbMetadataSettings settings, string imageBaseUrl, string? path, string size)

--- a/src/Tindarr.Infrastructure/Persistence/Entities/JoinAddressSettingsEntity.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Entities/JoinAddressSettingsEntity.cs
@@ -5,5 +5,7 @@ public sealed class JoinAddressSettingsEntity
 	public long Id { get; set; }
 	public string? LanHostPort { get; set; }
 	public string? WanHostPort { get; set; }
+	public int? RoomLifetimeMinutes { get; set; }
+	public int? GuestSessionLifetimeMinutes { get; set; }
 	public DateTimeOffset UpdatedAtUtc { get; set; }
 }

--- a/src/Tindarr.Infrastructure/Persistence/Migrations/20260217085319_AddRoomAndGuestLifetimeMinutesToJoinAddressSettings.Designer.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Migrations/20260217085319_AddRoomAndGuestLifetimeMinutesToJoinAddressSettings.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Tindarr.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using Tindarr.Infrastructure.Persistence;
 namespace Tindarr.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(TindarrDbContext))]
-    partial class TindarrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260217085319_AddRoomAndGuestLifetimeMinutesToJoinAddressSettings")]
+    partial class AddRoomAndGuestLifetimeMinutesToJoinAddressSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.23");

--- a/src/Tindarr.Infrastructure/Persistence/Migrations/20260217085319_AddRoomAndGuestLifetimeMinutesToJoinAddressSettings.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Migrations/20260217085319_AddRoomAndGuestLifetimeMinutesToJoinAddressSettings.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tindarr.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRoomAndGuestLifetimeMinutesToJoinAddressSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "GuestSessionLifetimeMinutes",
+                table: "JoinAddressSettings",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "RoomLifetimeMinutes",
+                table: "JoinAddressSettings",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GuestSessionLifetimeMinutes",
+                table: "JoinAddressSettings");
+
+            migrationBuilder.DropColumn(
+                name: "RoomLifetimeMinutes",
+                table: "JoinAddressSettings");
+        }
+    }
+}

--- a/src/Tindarr.Infrastructure/Persistence/Repositories/JoinAddressSettingsRepository.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Repositories/JoinAddressSettingsRepository.cs
@@ -27,6 +27,8 @@ public sealed class JoinAddressSettingsRepository(TindarrDbContext db) : IJoinAd
 			{
 				LanHostPort = upsert.LanHostPort,
 				WanHostPort = upsert.WanHostPort,
+				RoomLifetimeMinutes = upsert.RoomLifetimeMinutes,
+				GuestSessionLifetimeMinutes = upsert.GuestSessionLifetimeMinutes,
 				UpdatedAtUtc = now
 			};
 			db.JoinAddressSettings.Add(entity);
@@ -35,15 +37,17 @@ public sealed class JoinAddressSettingsRepository(TindarrDbContext db) : IJoinAd
 		{
 			entity.LanHostPort = upsert.LanHostPort;
 			entity.WanHostPort = upsert.WanHostPort;
+			entity.RoomLifetimeMinutes = upsert.RoomLifetimeMinutes;
+			entity.GuestSessionLifetimeMinutes = upsert.GuestSessionLifetimeMinutes;
 			entity.UpdatedAtUtc = now;
 		}
 
 		await db.SaveChangesAsync(cancellationToken);
-		return new JoinAddressSettingsRecord(entity.LanHostPort, entity.WanHostPort, entity.UpdatedAtUtc);
+		return new JoinAddressSettingsRecord(entity.LanHostPort, entity.WanHostPort, entity.RoomLifetimeMinutes, entity.GuestSessionLifetimeMinutes, entity.UpdatedAtUtc);
 	}
 
 	private static JoinAddressSettingsRecord Map(JoinAddressSettingsEntity entity)
 	{
-		return new JoinAddressSettingsRecord(entity.LanHostPort, entity.WanHostPort, entity.UpdatedAtUtc);
+		return new JoinAddressSettingsRecord(entity.LanHostPort, entity.WanHostPort, entity.RoomLifetimeMinutes, entity.GuestSessionLifetimeMinutes, entity.UpdatedAtUtc);
 	}
 }

--- a/src/Tindarr.Infrastructure/Persistence/Repositories/LibraryCacheRepository.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Repositories/LibraryCacheRepository.cs
@@ -20,6 +20,34 @@ public sealed class LibraryCacheRepository(TindarrDbContext db) : ILibraryCacheR
 		return ids;
 	}
 
+	public async Task<IReadOnlyList<int>> ListTmdbIdsAsync(ServiceScope scope, int skip, int take, CancellationToken cancellationToken)
+	{
+		skip = Math.Max(0, skip);
+		take = Math.Clamp(take, 1, 500);
+
+		var ids = await db.LibraryCache
+			.AsNoTracking()
+			.Where(x => x.ServiceType == scope.ServiceType && x.ServerId == scope.ServerId)
+			.OrderBy(x => x.TmdbId)
+			.Select(x => x.TmdbId)
+			.Distinct()
+			.Skip(skip)
+			.Take(take)
+			.ToListAsync(cancellationToken);
+
+		return ids;
+	}
+
+	public async Task<int> CountTmdbIdsAsync(ServiceScope scope, CancellationToken cancellationToken)
+	{
+		return await db.LibraryCache
+			.AsNoTracking()
+			.Where(x => x.ServiceType == scope.ServiceType && x.ServerId == scope.ServerId)
+			.Select(x => x.TmdbId)
+			.Distinct()
+			.CountAsync(cancellationToken);
+	}
+
 	public async Task ReplaceTmdbIdsAsync(ServiceScope scope, IReadOnlyCollection<int> tmdbIds, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken)
 	{
 		await db.LibraryCache

--- a/src/Tindarr.Infrastructure/Persistence/Repositories/RadarrPendingAddRepository.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Repositories/RadarrPendingAddRepository.cs
@@ -9,19 +9,29 @@ public sealed class RadarrPendingAddRepository(TindarrDbContext db) : IRadarrPen
 {
 	public async Task<DateTimeOffset?> GetNextReadyAtUtcAsync(CancellationToken cancellationToken)
 	{
-		// SQLite provider has limited DateTimeOffset translation support in LINQ.
-		// Use an in-memory fallback to avoid runtime translation exceptions.
-		var rows = await db.RadarrPendingAdds
-			.AsNoTracking()
-			.Where(x => x.CanceledAtUtc == null && x.ProcessedAtUtc == null)
-			.ToListAsync(cancellationToken);
-
-		if (rows.Count == 0)
+		try
 		{
-			return null;
+			// Avoid materializing the full pending set; let the database compute the next time.
+			return await db.RadarrPendingAdds
+				.AsNoTracking()
+				.Where(x => x.CanceledAtUtc == null && x.ProcessedAtUtc == null)
+				.OrderBy(x => x.ReadyAtUtc)
+				.Select(x => (DateTimeOffset?)x.ReadyAtUtc)
+				.FirstOrDefaultAsync(cancellationToken)
+				.ConfigureAwait(false);
 		}
+		catch (InvalidOperationException)
+		{
+			// SQLite provider can have limited DateTimeOffset translation support in LINQ.
+			// Fall back to an in-memory min to avoid runtime translation exceptions.
+			var rows = await db.RadarrPendingAdds
+				.AsNoTracking()
+				.Where(x => x.CanceledAtUtc == null && x.ProcessedAtUtc == null)
+				.ToListAsync(cancellationToken)
+				.ConfigureAwait(false);
 
-		return rows.Min(x => x.ReadyAtUtc);
+			return rows.Count == 0 ? null : rows.Min(x => x.ReadyAtUtc);
+		}
 	}
 
 	public async Task<bool> TryEnqueueAsync(

--- a/src/Tindarr.Infrastructure/Persistence/Repositories/RadarrPendingAddRepository.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Repositories/RadarrPendingAddRepository.cs
@@ -7,6 +7,23 @@ namespace Tindarr.Infrastructure.Persistence.Repositories;
 
 public sealed class RadarrPendingAddRepository(TindarrDbContext db) : IRadarrPendingAddRepository
 {
+	public async Task<DateTimeOffset?> GetNextReadyAtUtcAsync(CancellationToken cancellationToken)
+	{
+		// SQLite provider has limited DateTimeOffset translation support in LINQ.
+		// Use an in-memory fallback to avoid runtime translation exceptions.
+		var rows = await db.RadarrPendingAdds
+			.AsNoTracking()
+			.Where(x => x.CanceledAtUtc == null && x.ProcessedAtUtc == null)
+			.ToListAsync(cancellationToken);
+
+		if (rows.Count == 0)
+		{
+			return null;
+		}
+
+		return rows.Min(x => x.ReadyAtUtc);
+	}
+
 	public async Task<bool> TryEnqueueAsync(
 		ServiceScope scope,
 		string userId,

--- a/src/Tindarr.Infrastructure/PlexCache/Repositories/PlexLibraryCacheRepository.cs
+++ b/src/Tindarr.Infrastructure/PlexCache/Repositories/PlexLibraryCacheRepository.cs
@@ -26,6 +26,21 @@ public sealed class PlexLibraryCacheRepository(PlexCacheDbContext db) : IPlexLib
 		return ids;
 	}
 
+	public async Task<int> CountTmdbIdsAsync(ServiceScope scope, CancellationToken cancellationToken)
+	{
+		if (scope.ServiceType != ServiceType.Plex)
+		{
+			return 0;
+		}
+
+		return await db.LibraryItems
+			.AsNoTracking()
+			.Where(x => x.ServerId == scope.ServerId && x.TmdbId > 0)
+			.Select(x => x.TmdbId)
+			.Distinct()
+			.CountAsync(cancellationToken);
+	}
+
 	public async Task<IReadOnlyList<PlexLibraryItem>> ListItemsAsync(ServiceScope scope, int skip, int take, CancellationToken cancellationToken)
 	{
 		if (scope.ServiceType != ServiceType.Plex)

--- a/src/Tindarr.Infrastructure/PlexCache/Repositories/PlexLibraryCacheRepository.cs
+++ b/src/Tindarr.Infrastructure/PlexCache/Repositories/PlexLibraryCacheRepository.cs
@@ -53,7 +53,7 @@ public sealed class PlexLibraryCacheRepository(PlexCacheDbContext db) : IPlexLib
 
 		var rows = await db.LibraryItems
 			.AsNoTracking()
-			.Where(x => x.ServerId == scope.ServerId)
+			.Where(x => x.ServerId == scope.ServerId && x.TmdbId > 0)
 			.OrderByDescending(x => x.UpdatedAtUtc)
 			.ThenBy(x => x.TmdbId)
 			.Skip(skip)
@@ -63,7 +63,6 @@ public sealed class PlexLibraryCacheRepository(PlexCacheDbContext db) : IPlexLib
 			.ConfigureAwait(false);
 
 		return rows
-			.Where(x => x.TmdbId > 0)
 			.Select(x => new PlexLibraryItem(
 				TmdbId: x.TmdbId,
 				Title: string.IsNullOrWhiteSpace(x.Title) ? $"TMDB:{x.TmdbId}" : x.Title!,

--- a/src/Tindarr.Infrastructure/Rooms/InMemoryRoomInteractionStore.cs
+++ b/src/Tindarr.Infrastructure/Rooms/InMemoryRoomInteractionStore.cs
@@ -4,9 +4,8 @@ using Tindarr.Domain.Interactions;
 
 namespace Tindarr.Infrastructure.Rooms;
 
-public sealed class InMemoryRoomInteractionStore : IRoomInteractionStore
+public sealed class InMemoryRoomInteractionStore(IRoomLifetimeProvider lifetimes) : IRoomInteractionStore
 {
-	private static readonly TimeSpan Ttl = TimeSpan.FromHours(2);
 	private readonly ConcurrentDictionary<string, RoomInteractionBucket> _buckets = new(StringComparer.Ordinal);
 
 	public Task AddAsync(string roomId, Interaction interaction, CancellationToken cancellationToken)
@@ -28,10 +27,15 @@ public sealed class InMemoryRoomInteractionStore : IRoomInteractionStore
 			return Task.FromResult<IReadOnlyList<Interaction>>(Array.Empty<Interaction>());
 		}
 
-		if (IsExpired(bucket))
+		return ListOrExpireAsync(roomId, bucket, limit, cancellationToken);
+	}
+
+	private async Task<IReadOnlyList<Interaction>> ListOrExpireAsync(string roomId, RoomInteractionBucket bucket, int limit, CancellationToken cancellationToken)
+	{
+		if (await IsExpiredAsync(bucket, cancellationToken).ConfigureAwait(false))
 		{
 			_buckets.TryRemove(roomId, out _);
-			return Task.FromResult<IReadOnlyList<Interaction>>(Array.Empty<Interaction>());
+			return Array.Empty<Interaction>();
 		}
 
 		lock (bucket.Gate)
@@ -41,27 +45,31 @@ public sealed class InMemoryRoomInteractionStore : IRoomInteractionStore
 				.OrderByDescending(x => x.CreatedAtUtc)
 				.Take(Math.Clamp(limit, 1, 50_000))
 				.ToList();
-			return Task.FromResult<IReadOnlyList<Interaction>>(result);
+			return result;
 		}
 	}
 
 	public Task CleanupExpiredAsync(CancellationToken cancellationToken)
 	{
+		return CleanupExpiredInnerAsync(cancellationToken);
+	}
+
+	private async Task CleanupExpiredInnerAsync(CancellationToken cancellationToken)
+	{
 		foreach (var kvp in _buckets)
 		{
-			if (IsExpired(kvp.Value))
+			if (await IsExpiredAsync(kvp.Value, cancellationToken).ConfigureAwait(false))
 			{
 				_buckets.TryRemove(kvp.Key, out _);
 			}
 		}
-
-		return Task.CompletedTask;
 	}
 
-	private static bool IsExpired(RoomInteractionBucket bucket)
+	private async Task<bool> IsExpiredAsync(RoomInteractionBucket bucket, CancellationToken cancellationToken)
 	{
 		var now = DateTimeOffset.UtcNow;
-		return now - bucket.LastActivityAtUtc > Ttl;
+		var ttl = await lifetimes.GetRoomTtlAsync(cancellationToken).ConfigureAwait(false);
+		return now - bucket.LastActivityAtUtc > ttl;
 	}
 
 	private sealed class RoomInteractionBucket

--- a/src/Tindarr.Infrastructure/Rooms/InMemoryRoomStore.cs
+++ b/src/Tindarr.Infrastructure/Rooms/InMemoryRoomStore.cs
@@ -4,9 +4,8 @@ using Tindarr.Domain.Rooms;
 
 namespace Tindarr.Infrastructure.Rooms;
 
-public sealed class InMemoryRoomStore : IRoomStore
+public sealed class InMemoryRoomStore(IRoomLifetimeProvider lifetimes) : IRoomStore
 {
-	private static readonly TimeSpan Ttl = TimeSpan.FromHours(2);
 	private readonly ConcurrentDictionary<string, RoomState> _rooms = new(StringComparer.Ordinal);
 
 	public Task CreateAsync(RoomState state, CancellationToken cancellationToken)
@@ -22,13 +21,18 @@ public sealed class InMemoryRoomStore : IRoomStore
 			return Task.FromResult<RoomState?>(null);
 		}
 
-		if (IsExpired(state))
+		return GetOrExpireAsync(roomId, state, cancellationToken);
+	}
+
+	private async Task<RoomState?> GetOrExpireAsync(string roomId, RoomState state, CancellationToken cancellationToken)
+	{
+		if (await IsExpiredAsync(state, cancellationToken).ConfigureAwait(false))
 		{
 			_rooms.TryRemove(roomId, out _);
-			return Task.FromResult<RoomState?>(null);
+			return null;
 		}
 
-		return Task.FromResult<RoomState?>(state);
+		return state;
 	}
 
 	public Task UpdateAsync(RoomState state, CancellationToken cancellationToken)
@@ -39,20 +43,24 @@ public sealed class InMemoryRoomStore : IRoomStore
 
 	public Task CleanupExpiredAsync(CancellationToken cancellationToken)
 	{
+		return CleanupExpiredInnerAsync(cancellationToken);
+	}
+
+	private async Task CleanupExpiredInnerAsync(CancellationToken cancellationToken)
+	{
 		foreach (var kvp in _rooms)
 		{
-			if (IsExpired(kvp.Value))
+			if (await IsExpiredAsync(kvp.Value, cancellationToken).ConfigureAwait(false))
 			{
 				_rooms.TryRemove(kvp.Key, out _);
 			}
 		}
-
-		return Task.CompletedTask;
 	}
 
-	private static bool IsExpired(RoomState state)
+	private async Task<bool> IsExpiredAsync(RoomState state, CancellationToken cancellationToken)
 	{
 		var now = DateTimeOffset.UtcNow;
-		return now - state.LastActivityAtUtc > Ttl;
+		var ttl = await lifetimes.GetRoomTtlAsync(cancellationToken).ConfigureAwait(false);
+		return now - state.LastActivityAtUtc > ttl;
 	}
 }

--- a/src/Tindarr.Infrastructure/Rooms/RoomLifetimeProvider.cs
+++ b/src/Tindarr.Infrastructure/Rooms/RoomLifetimeProvider.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Tindarr.Application.Abstractions.Persistence;
+using Tindarr.Application.Interfaces.Rooms;
+using Tindarr.Application.Options;
+
+namespace Tindarr.Infrastructure.Rooms;
+
+public sealed class RoomLifetimeProvider(
+	IServiceScopeFactory scopeFactory,
+	IMemoryCache cache,
+	IOptions<JwtOptions> jwtOptions) : IRoomLifetimeProvider
+{
+	private static readonly object CacheKey = new();
+	private readonly JwtOptions jwt = jwtOptions.Value;
+
+	public async Task<TimeSpan> GetRoomTtlAsync(CancellationToken cancellationToken)
+		=> (await GetAsync(cancellationToken).ConfigureAwait(false)).RoomTtl;
+
+	public async Task<TimeSpan> GetGuestSessionTtlAsync(CancellationToken cancellationToken)
+		=> (await GetAsync(cancellationToken).ConfigureAwait(false)).GuestSessionTtl;
+
+	private Task<ResolvedLifetimes> GetAsync(CancellationToken cancellationToken)
+	{
+		return cache.GetOrCreateAsync(CacheKey, async entry =>
+		{
+			entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(30);
+
+			using var scope = scopeFactory.CreateScope();
+			var repo = scope.ServiceProvider.GetRequiredService<IJoinAddressSettingsRepository>();
+			var settings = await repo.GetAsync(cancellationToken).ConfigureAwait(false);
+
+			var roomMinutes = settings?.RoomLifetimeMinutes;
+			var guestMinutes = settings?.GuestSessionLifetimeMinutes;
+
+			var roomTtl = TimeSpan.FromMinutes(
+				roomMinutes is > 0 ? roomMinutes.Value : 120);
+			var guestTtl = TimeSpan.FromMinutes(
+				guestMinutes is > 0 ? guestMinutes.Value : Math.Clamp(jwt.AccessTokenMinutes, 1, 24 * 60));
+
+			return new ResolvedLifetimes(roomTtl, guestTtl);
+		})!;
+	}
+
+	private sealed record ResolvedLifetimes(TimeSpan RoomTtl, TimeSpan GuestSessionTtl);
+}

--- a/src/Tindarr.Infrastructure/Security/JwtTokenService.cs
+++ b/src/Tindarr.Infrastructure/Security/JwtTokenService.cs
@@ -12,10 +12,16 @@ public sealed class JwtTokenService(IOptions<JwtOptions> jwtOptions, ITokenSigni
 	private readonly JwtOptions options = jwtOptions.Value;
 	private readonly JwtSecurityTokenHandler handler = new();
 
-	public TokenResult IssueAccessToken(string userId, IReadOnlyCollection<string> roles)
+	public TokenResult IssueAccessToken(
+		string userId,
+		IReadOnlyCollection<string> roles,
+		IReadOnlyCollection<Claim>? additionalClaims = null,
+		TimeSpan? lifetimeOverride = null)
 	{
 		var now = DateTimeOffset.UtcNow;
-		var expires = now.AddMinutes(options.AccessTokenMinutes);
+		var expires = lifetimeOverride is not null
+			? now.Add(lifetimeOverride.Value)
+			: now.AddMinutes(options.AccessTokenMinutes);
 
 		var claims = new List<Claim>
 		{
@@ -27,6 +33,19 @@ public sealed class JwtTokenService(IOptions<JwtOptions> jwtOptions, ITokenSigni
 		foreach (var role in roles.Distinct(StringComparer.OrdinalIgnoreCase))
 		{
 			claims.Add(new Claim(ClaimTypes.Role, role));
+		}
+
+		if (additionalClaims is not null)
+		{
+			foreach (var claim in additionalClaims)
+			{
+				// Avoid duplicates that would bloat tokens.
+				if (!claims.Any(c => string.Equals(c.Type, claim.Type, StringComparison.Ordinal)
+					&& string.Equals(c.Value, claim.Value, StringComparison.Ordinal)))
+				{
+					claims.Add(claim);
+				}
+			}
 		}
 
 		var active = keyStore.GetActiveSigningKey();

--- a/src/Tindarr.Workers/Jobs/MatchComputationWorker.cs
+++ b/src/Tindarr.Workers/Jobs/MatchComputationWorker.cs
@@ -54,7 +54,20 @@ public sealed class MatchComputationWorker(
 			{
 				if (settings.MatchMinUsers is not null)
 				{
-					effectiveMinUsers = Math.Clamp(settings.MatchMinUsers.Value, 0, 50);
+					// MinUsers is validated as 1..50 in AdminController; treat <=0 as legacy/invalid and fall back to defaults.
+					if (settings.MatchMinUsers.Value > 0)
+					{
+						effectiveMinUsers = Math.Clamp(settings.MatchMinUsers.Value, 1, 50);
+					}
+					else if (settings.MatchMinUserPercent is null)
+					{
+						effectiveMinUsers = 2;
+					}
+					else
+					{
+						// Percent-only configuration disables count threshold.
+						effectiveMinUsers = 0;
+					}
 				}
 				else if (settings.MatchMinUserPercent is not null)
 				{

--- a/src/Tindarr.Workers/Jobs/RadarrSuperlikeAddWorker.cs
+++ b/src/Tindarr.Workers/Jobs/RadarrSuperlikeAddWorker.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Tindarr.Application.Abstractions.Persistence;
 using Tindarr.Application.Interfaces.Integrations;
 using Tindarr.Domain.Common;
@@ -8,11 +9,66 @@ namespace Tindarr.Workers.Jobs;
 
 public sealed class RadarrSuperlikeAddWorker(
 	IServiceScopeFactory scopeFactory,
-	ILogger<RadarrSuperlikeAddWorker> logger) : PeriodicBackgroundService(logger)
+	ILogger<RadarrSuperlikeAddWorker> logger) : BackgroundService
 {
-	protected override TimeSpan Interval => TimeSpan.FromSeconds(1);
+	// Cross-process notification (API -> Workers) isn't wired up today, so we still have to
+	// wake up periodically. Keep the idle tick modest to reduce churn while staying responsive.
+	private static readonly TimeSpan MaxIdleDelay = TimeSpan.FromSeconds(10);
+	private static readonly TimeSpan ErrorBackoffDelay = TimeSpan.FromSeconds(5);
 
-	protected override async Task ExecuteOnceAsync(CancellationToken stoppingToken)
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+	{
+		while (!stoppingToken.IsCancellationRequested)
+		{
+			try
+			{
+				var processedAny = await ExecuteOnceAsync(stoppingToken).ConfigureAwait(false);
+				if (processedAny)
+				{
+					// Immediately loop to pick up any additional due items.
+					continue;
+				}
+
+				var delay = await ComputeNextDelayAsync(stoppingToken).ConfigureAwait(false);
+				if (delay > TimeSpan.Zero)
+				{
+					await Task.Delay(delay, stoppingToken).ConfigureAwait(false);
+				}
+			}
+			catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+			{
+				return;
+			}
+			catch (Exception ex)
+			{
+				logger.LogError(ex, "Worker iteration failed for {WorkerType}", GetType().Name);
+				await Task.Delay(ErrorBackoffDelay, stoppingToken).ConfigureAwait(false);
+			}
+		}
+	}
+
+	private async Task<TimeSpan> ComputeNextDelayAsync(CancellationToken stoppingToken)
+	{
+		using var diScope = scopeFactory.CreateScope();
+		var pendingAdds = diScope.ServiceProvider.GetRequiredService<IRadarrPendingAddRepository>();
+
+		var nextReadyAt = await pendingAdds.GetNextReadyAtUtcAsync(stoppingToken).ConfigureAwait(false);
+		if (nextReadyAt is null)
+		{
+			return MaxIdleDelay;
+		}
+
+		var now = DateTimeOffset.UtcNow;
+		var delay = nextReadyAt.Value - now;
+		if (delay <= TimeSpan.Zero)
+		{
+			return TimeSpan.Zero;
+		}
+
+		return delay > MaxIdleDelay ? MaxIdleDelay : delay;
+	}
+
+	private async Task<bool> ExecuteOnceAsync(CancellationToken stoppingToken)
 	{
 		using var diScope = scopeFactory.CreateScope();
 		var pendingAdds = diScope.ServiceProvider.GetRequiredService<IRadarrPendingAddRepository>();
@@ -22,10 +78,10 @@ public sealed class RadarrSuperlikeAddWorker(
 		var due = await pendingAdds.ListDueAsync(now, limit: 50, stoppingToken);
 		if (due.Count == 0)
 		{
-			return;
+			return false;
 		}
 
-		Logger.LogInformation("radarr superlike add: processing {Count} due items", due.Count);
+		logger.LogInformation("radarr superlike add: processing {Count} due items", due.Count);
 
 		foreach (var item in due)
 		{
@@ -48,7 +104,7 @@ public sealed class RadarrSuperlikeAddWorker(
 				var result = await radarr.AddMovieAsync(scope, item.TmdbId, stoppingToken);
 				if (result.Added || result.AlreadyExists)
 				{
-					Logger.LogInformation(
+					logger.LogInformation(
 						"radarr superlike add succeeded for {ServerId} tmdb:{TmdbId} (added={Added} exists={Exists})",
 						item.ServerId,
 						item.TmdbId,
@@ -58,7 +114,7 @@ public sealed class RadarrSuperlikeAddWorker(
 					continue;
 				}
 
-				Logger.LogWarning(
+				logger.LogWarning(
 					"radarr superlike add failed for {ServerId} tmdb:{TmdbId}: {Message}",
 					item.ServerId,
 					item.TmdbId,
@@ -84,5 +140,7 @@ public sealed class RadarrSuperlikeAddWorker(
 					stoppingToken);
 			}
 		}
+
+		return true;
 	}
 }

--- a/src/Tindarr.Workers/Jobs/TmdbDiscoverPrewarmWorker.cs
+++ b/src/Tindarr.Workers/Jobs/TmdbDiscoverPrewarmWorker.cs
@@ -60,8 +60,24 @@ public sealed class TmdbDiscoverPrewarmWorker(
 			try
 			{
 				var prefs = await prefsService.GetOrDefaultAsync(user.Id, stoppingToken).ConfigureAwait(false);
-				var discovered = await tmdbClient.DiscoverMoviesAsync(prefs, page: 1, limit: 50, stoppingToken).ConfigureAwait(false);
-				await metadataStore.AddToUserPoolAsync(user.Id, discovered, stoppingToken).ConfigureAwait(false);
+				var effectivePrefs = prefs;
+				if (!string.IsNullOrWhiteSpace(settings.PrewarmOriginalLanguage))
+				{
+					effectivePrefs = effectivePrefs with
+					{
+						PreferredOriginalLanguages = new[] { settings.PrewarmOriginalLanguage }
+					};
+				}
+				if (!string.IsNullOrWhiteSpace(settings.PrewarmRegion))
+				{
+					effectivePrefs = effectivePrefs with
+					{
+						PreferredRegions = new[] { settings.PrewarmRegion }
+					};
+				}
+
+				var discovered = await tmdbClient.DiscoverMoviesAsync(effectivePrefs, page: 1, limit: 50, stoppingToken).ConfigureAwait(false);
+				await metadataStore.UpsertMoviesAsync(discovered, stoppingToken).ConfigureAwait(false);
 
 				if (settings.PosterMode == TmdbPosterMode.LocalProxy && settings.ImageCacheMaxMb > 0)
 				{

--- a/src/Tindarr.Workers/Program.cs
+++ b/src/Tindarr.Workers/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Hosting.WindowsServices;
@@ -45,6 +46,20 @@ var tmdbApiKeyEnv = Environment.GetEnvironmentVariable("TMDB_API_KEY");
 if (!string.IsNullOrWhiteSpace(tmdbApiKeyEnv) && string.IsNullOrWhiteSpace(builder.Configuration["Tmdb:ApiKey"]))
 {
 	builder.Configuration["Tmdb:ApiKey"] = tmdbApiKeyEnv;
+}
+
+static string ResolveTmdbMetadataDbPath(IConfiguration config, string? dataDirOverride, IHostEnvironment env)
+{
+	var configuredDbPath = config["Tmdb:MetadataDbPath"];
+	if (!string.IsNullOrWhiteSpace(configuredDbPath))
+	{
+		return Path.IsPathRooted(configuredDbPath)
+			? configuredDbPath
+			: Path.GetFullPath(Path.Combine(dataDirOverride ?? config["Database:DataDir"] ?? env.ContentRootPath, configuredDbPath));
+	}
+
+	var dataRoot = dataDirOverride ?? config["Database:DataDir"] ?? env.ContentRootPath;
+	return Path.Combine(dataRoot, "tmdbmetadata.db");
 }
 
 if (isWindowsService)
@@ -110,6 +125,8 @@ var defaultDataDirOverride = string.IsNullOrWhiteSpace(configuredDataDir) && Dir
 	? devApiDataDir
 	: null;
 
+var tmdbMetadataDbPath = ResolveTmdbMetadataDbPath((IConfiguration)builder.Configuration, defaultDataDirOverride, builder.Environment);
+
 builder.Services.AddTindarrPersistence(builder.Configuration, overrideDataDir: defaultDataDirOverride);
 builder.Services.AddPlexCache(builder.Configuration, overrideDataDir: defaultDataDirOverride);
 
@@ -139,21 +156,18 @@ builder.Services.AddHttpClient<IEmbyClient, EmbyClient>();
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<ITmdbCache>(sp =>
 {
-	var tmdbMetadataDbPath = Path.Combine(builder.Environment.ContentRootPath, "tmdbmetadata.db");
 	return new MemoryOrDbTmdbCache(sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>(), tmdbMetadataDbPath);
 });
 builder.Services.AddSingleton<ITmdbCacheAdmin>(sp => (ITmdbCacheAdmin)sp.GetRequiredService<ITmdbCache>());
 
 builder.Services.AddSingleton<ITmdbMetadataStore>(sp =>
 {
-	var tmdbMetadataDbPath = Path.Combine(builder.Environment.ContentRootPath, "tmdbmetadata.db");
 	return new TmdbMetadataStore(tmdbMetadataDbPath);
 });
 
 builder.Services.AddHttpClient("tmdb-images");
 builder.Services.AddSingleton<ITmdbImageCache>(sp =>
 {
-	var tmdbMetadataDbPath = Path.Combine(builder.Environment.ContentRootPath, "tmdbmetadata.db");
 	var client = sp.GetRequiredService<IHttpClientFactory>().CreateClient("tmdb-images");
 	return new TmdbImageCache(client, sp.GetRequiredService<IOptions<TmdbOptions>>(), tmdbMetadataDbPath);
 });

--- a/tests/Tindarr.UnitTests/Infrastructure/Playback/PlexPlaybackProviderStreamSelectionTests.cs
+++ b/tests/Tindarr.UnitTests/Infrastructure/Playback/PlexPlaybackProviderStreamSelectionTests.cs
@@ -216,6 +216,9 @@ public sealed class PlexPlaybackProviderStreamSelectionTests
 		public Task<IReadOnlyCollection<int>> GetTmdbIdsAsync(ServiceScope scope, CancellationToken cancellationToken) =>
 			throw new NotSupportedException();
 
+		public Task<int> CountTmdbIdsAsync(ServiceScope scope, CancellationToken cancellationToken) =>
+			throw new NotSupportedException();
+
 		public Task<IReadOnlyList<PlexLibraryItem>> ListItemsAsync(ServiceScope scope, int skip, int take, CancellationToken cancellationToken) =>
 			throw new NotSupportedException();
 

--- a/tests/Tindarr.UnitTests/Interactions/SwipeDeckServiceTests.cs
+++ b/tests/Tindarr.UnitTests/Interactions/SwipeDeckServiceTests.cs
@@ -71,6 +71,16 @@ public sealed class SwipeDeckServiceTests
 			return Task.FromResult<IReadOnlyCollection<int>>(Array.Empty<int>());
 		}
 
+		public Task<IReadOnlyList<int>> ListTmdbIdsAsync(ServiceScope scope, int skip, int take, CancellationToken cancellationToken)
+		{
+			return Task.FromResult<IReadOnlyList<int>>(Array.Empty<int>());
+		}
+
+		public Task<int> CountTmdbIdsAsync(ServiceScope scope, CancellationToken cancellationToken)
+		{
+			return Task.FromResult(0);
+		}
+
 		public Task ReplaceTmdbIdsAsync(ServiceScope scope, IReadOnlyCollection<int> tmdbIds, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken)
 		{
 			throw new NotSupportedException();

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -52,6 +52,7 @@ import type {
   StartTmdbBuildRequest,
   TmdbBuildStatusDto,
   TmdbStoredMovieAdminListResponse,
+  AdminDbMovieListResponse,
   TmdbFetchMovieImagesResultDto
   ,
   CreateRoomRequest,
@@ -224,6 +225,19 @@ export async function adminUpdateMatchSettings(
     method: "PUT",
     query: { serviceType: serviceType.trim().toLowerCase(), serverId: serverId.trim() || "default" },
     body: request
+  });
+}
+
+export async function adminDbListMovies(params: { skip?: number; take?: number } = {}): Promise<AdminDbMovieListResponse> {
+  const scope = resolveScope();
+  return apiRequest<AdminDbMovieListResponse>({
+    path: "/api/v1/admin/db/movies",
+    query: {
+      serviceType: scope.serviceType,
+      serverId: scope.serverId,
+      skip: params.skip ?? 0,
+      take: params.take ?? 50
+    }
   });
 }
 

--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -18,6 +18,7 @@ export type RegisterRequest = {
 };
 
 export type GuestLoginRequest = {
+  roomId: string;
   displayName?: string | null;
 };
 
@@ -38,6 +39,8 @@ export type UserDto = {
 export type JoinAddressSettingsDto = {
   lanHostPort: string | null;
   wanHostPort: string | null;
+  roomLifetimeMinutes: number | null;
+  guestSessionLifetimeMinutes: number | null;
   updatedAtUtc: string;
 };
 
@@ -74,6 +77,8 @@ export type ServiceScopeOptionDto = {
 export type UpdateJoinAddressSettingsRequest = {
   lanHostPort: string | null;
   wanHostPort: string | null;
+  roomLifetimeMinutes: number | null;
+  guestSessionLifetimeMinutes: number | null;
 };
 
 export type UpdateCastingSettingsRequest = {
@@ -263,6 +268,8 @@ export type TmdbCacheSettingsDto = {
   imageCacheMaxMb: number;
   imageCacheBytes: number;
   posterMode: string;
+  prewarmOriginalLanguage: string | null;
+  prewarmRegion: string | null;
 };
 
 export type UpdateTmdbCacheSettingsRequest = {
@@ -270,6 +277,8 @@ export type UpdateTmdbCacheSettingsRequest = {
   maxMovies: number;
   imageCacheMaxMb: number;
   posterMode: string;
+  prewarmOriginalLanguage: string | null;
+  prewarmRegion: string | null;
 };
 
 export type StartTmdbBuildRequest = {
@@ -312,6 +321,15 @@ export type TmdbStoredMovieAdminListResponse = {
   take: number;
   nextSkip: number;
   hasMore: boolean;
+};
+
+export type AdminDbMovieListResponse = {
+  items: TmdbStoredMovieAdminDto[];
+  skip: number;
+  take: number;
+  nextSkip: number;
+  hasMore: boolean;
+  totalCount: number;
 };
 
 export type TmdbFetchMovieImagesResultDto = {

--- a/ui/src/auth/AuthContext.tsx
+++ b/ui/src/auth/AuthContext.tsx
@@ -7,7 +7,7 @@ type AuthContextValue = {
   user: MeResponse | null;
   loading: boolean;
   login: (userId: string, password: string) => Promise<void>;
-  guestLogin: (displayName?: string) => Promise<void>;
+  guestLogin: (roomId: string, displayName?: string) => Promise<void>;
   register: (userId: string, displayName: string, password: string) => Promise<void>;
   logout: () => void;
 };
@@ -51,8 +51,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setSession(session);
         setUser(mapAuthToMe(session));
       },
-      guestLogin: async (displayName?: string) => {
-        const session = await apiGuestLogin({ displayName: displayName ?? null });
+      guestLogin: async (roomId: string, displayName?: string) => {
+        const session = await apiGuestLogin({ roomId, displayName: displayName ?? null });
         setSession(session);
         setUser(mapAuthToMe(session));
       },

--- a/ui/src/pages/AdminConsolePage.tsx
+++ b/ui/src/pages/AdminConsolePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ApiError } from "../api/http";
 import {
+  adminDbListMovies,
   adminCreateUser,
   adminDeleteUser,
   adminGetCastingSettings,
@@ -35,6 +36,7 @@ import {
   radarrSyncLibrary,
   radarrTestConnection,
   radarrUpsertSettings,
+  fetchMovieDetails,
   tmdbGetCacheSettings,
   tmdbUpdateCacheSettings,
   tmdbCancelBuild,
@@ -58,6 +60,7 @@ import type {
   TmdbCacheSettingsDto,
   TmdbBuildStatusDto,
   TmdbStoredMovieAdminDto,
+  MovieDetailsDto,
   UserDto
 } from "../api/contracts";
 import {
@@ -67,6 +70,7 @@ import {
   subscribeTmdbBulkJob,
   type TmdbBulkJob
 } from "../tmdb/tmdbBulkJob";
+import { TMDB_LANGUAGES, TMDB_REGIONS } from "../tmdb/knownValues";
 import {
 	getPlexBulkJob,
 	startPlexBulkFetchAllDetails,
@@ -74,6 +78,9 @@ import {
 	subscribePlexBulkJob,
 	type PlexBulkJob
 } from "../plex/plexBulkJob";
+
+import { getServiceScope, SERVICE_SCOPE_UPDATED_EVENT } from "../serviceScope";
+import PosterGallery from "../components/PosterGallery";
 
 type AdminUserRowState = {
   displayName: string;
@@ -107,7 +114,7 @@ function roleButtonClass(role: AppRole) {
 }
 
 export default function AdminConsolePage() {
-  const [tab, setTab] = useState<"users" | "plex" | "radarr" | "jellyfin" | "emby" | "tmdb" | "rooms" | "casting">("users");
+  const [tab, setTab] = useState<"users" | "plex" | "radarr" | "jellyfin" | "emby" | "tmdb" | "rooms" | "casting" | "db">("users");
 
   return (
     <section className="deck">
@@ -116,6 +123,7 @@ export default function AdminConsolePage() {
         <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
           <button type="button" className={tabButtonClass(tab === "users")} onClick={() => setTab("users")}>Users</button>
           <button type="button" className={tabButtonClass(tab === "rooms")} onClick={() => setTab("rooms")}>Rooms</button>
+          <button type="button" className={tabButtonClass(tab === "db")} onClick={() => setTab("db")}>DB</button>
           <button type="button" className={tabButtonClass(tab === "casting")} onClick={() => setTab("casting")}>Casting</button>
           <button type="button" className={tabButtonClass(tab === "plex")} onClick={() => setTab("plex")}>Plex</button>
           <button type="button" className={tabButtonClass(tab === "radarr")} onClick={() => setTab("radarr")}>Radarr</button>
@@ -127,12 +135,210 @@ export default function AdminConsolePage() {
 
       {tab === "users" ? <UsersTab /> : null}
       {tab === "rooms" ? <RoomsTab /> : null}
+      {tab === "db" ? <DbTab /> : null}
       {tab === "casting" ? <CastingTab /> : null}
       {tab === "plex" ? <PlexTab /> : null}
       {tab === "radarr" ? <RadarrTab /> : null}
       {tab === "jellyfin" ? <JellyfinTab /> : null}
       {tab === "emby" ? <EmbyTab /> : null}
       {tab === "tmdb" ? <TmdbTab /> : null}
+    </section>
+  );
+}
+
+function DbTab() {
+  const [scope, setScope] = useState(() => getServiceScope());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [movies, setMovies] = useState<TmdbStoredMovieAdminDto[]>([]);
+  const [moviesSkip, setMoviesSkip] = useState(0);
+  const [moviesNextSkip, setMoviesNextSkip] = useState(0);
+  const [moviesHasMore, setMoviesHasMore] = useState(false);
+  const [totalCount, setTotalCount] = useState(0);
+  const [view, setView] = useState<"table" | "gallery">("table");
+  const [detailsByTmdbId, setDetailsByTmdbId] = useState<Record<number, MovieDetailsDto>>({});
+
+  const load = async (skip: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await adminDbListMovies({ skip, take: 50 });
+      setMovies(res.items);
+      setMoviesSkip(res.skip);
+      setMoviesNextSkip(res.nextSkip);
+      setMoviesHasMore(res.hasMore);
+      setTotalCount(res.totalCount ?? 0);
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Failed to load DB movie records.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const pageSize = 50;
+  const currentPage = Math.floor(moviesSkip / pageSize) + 1;
+  const totalPages = Math.max(1, Math.ceil(Math.max(0, totalCount) / pageSize));
+
+  const formatCompactUtc = (value: string | null | undefined) => {
+    if (!value) return "—";
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return value;
+    return d.toLocaleString(undefined, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit"
+    });
+  };
+
+  useEffect(() => {
+    void load(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const onScope = () => {
+      const next = getServiceScope();
+      setScope(next);
+      setDetailsByTmdbId({});
+      void load(0);
+    };
+    window.addEventListener(SERVICE_SCOPE_UPDATED_EVENT, onScope);
+    return () => window.removeEventListener(SERVICE_SCOPE_UPDATED_EVENT, onScope);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (view !== "gallery") return;
+
+    const ids = movies.map((m) => m.tmdbId);
+    const missing = ids.filter((id) => detailsByTmdbId[id] === undefined).slice(0, 40);
+    if (missing.length === 0) return;
+
+    let cancelled = false;
+    (async () => {
+      const concurrency = 6;
+      for (let i = 0; i < missing.length; i += concurrency) {
+        const batch = missing.slice(i, i + concurrency);
+        const results = await Promise.allSettled(batch.map((id) => fetchMovieDetails(id)));
+        if (cancelled) return;
+
+        setDetailsByTmdbId((prev) => {
+          const next = { ...prev };
+          for (const r of results) {
+            if (r.status === "fulfilled") {
+              next[r.value.tmdbId] = r.value;
+            }
+          }
+          return next;
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [detailsByTmdbId, movies, view]);
+
+  const galleryItems = useMemo(() => {
+    return movies.map((m) => {
+      const details = detailsByTmdbId[m.tmdbId];
+      const title = details?.title ?? m.title ?? `TMDB #${m.tmdbId}`;
+      return {
+        key: String(m.tmdbId),
+        tmdbId: m.tmdbId,
+        title,
+        year: details?.releaseYear ?? m.releaseYear ?? null,
+        posterUrl: details?.posterUrl ?? null,
+        ribbon: { label: "DB", variant: "matched" as const }
+      };
+    });
+  }, [detailsByTmdbId, movies]);
+
+  return (
+    <section style={{ marginTop: "1rem" }}>
+      <h3 style={{ marginTop: 0 }}>DB</h3>
+      <div className="deck__state" style={{ textAlign: "left" }}>
+        <p style={{ marginTop: 0 }}>
+          Lists movie records for the current scope: <span className="adminTable__mono">{scope.serviceType}:{scope.serverId}</span>.
+        </p>
+
+        {loading ? <div className="deck__state">Loading movies…</div> : null}
+        {error ? <div className="deck__state deck__state--error">{error}</div> : null}
+
+        <div className="deck__toolbar" style={{ justifyContent: "space-between", flexWrap: "wrap" }}>
+          <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+            <button type="button" className={`button button--ghost ${view === "table" ? "is-active" : ""}`.trim()} onClick={() => setView("table")}>
+              Table
+            </button>
+            <button type="button" className={`button button--ghost ${view === "gallery" ? "is-active" : ""}`.trim()} onClick={() => setView("gallery")}>
+              Gallery
+            </button>
+          </div>
+          <div style={{ color: "#8c93a6", fontWeight: 600 }}>
+            Page {currentPage} of {totalPages}
+          </div>
+        </div>
+
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "flex-end" }}>
+          <button type="button" className="button button--neutral" onClick={() => load(0)} disabled={loading}>
+            Refresh list
+          </button>
+          <button
+            type="button"
+            className="button button--neutral"
+            onClick={() => load(Math.max(0, moviesSkip - 50))}
+            disabled={loading || moviesSkip <= 0}
+          >
+            Prev
+          </button>
+          <button
+            type="button"
+            className="button button--neutral"
+            onClick={() => load(moviesNextSkip)}
+            disabled={loading || !moviesHasMore}
+          >
+            Next
+          </button>
+        </div>
+
+        {view === "gallery" ? (
+          !loading && movies.length > 0 ? (
+            <PosterGallery items={galleryItems} onSelect={() => {}} />
+          ) : null
+        ) : (
+          <div style={{ marginTop: "0.75rem", overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr>
+                  <th style={{ textAlign: "left", padding: "0.5rem" }}>TMDB</th>
+                  <th style={{ textAlign: "left", padding: "0.5rem" }}>Title</th>
+                  <th style={{ textAlign: "left", padding: "0.5rem" }}>Details fetched</th>
+                  <th style={{ textAlign: "left", padding: "0.5rem" }}>Updated</th>
+                </tr>
+              </thead>
+              <tbody>
+                {movies.map((m) => (
+                  <tr key={m.tmdbId} style={{ borderTop: "1px solid rgba(255,255,255,0.08)" }}>
+                    <td style={{ padding: "0.5rem", whiteSpace: "nowrap" }}>{m.tmdbId}</td>
+                    <td style={{ padding: "0.5rem" }}>{m.title}{m.releaseYear ? ` (${m.releaseYear})` : ""}</td>
+                    <td style={{ padding: "0.5rem" }}>{m.detailsFetchedAtUtc ? "Yes" : "No"}</td>
+                    <td style={{ padding: "0.5rem", whiteSpace: "nowrap" }}>{formatCompactUtc(m.updatedAtUtc)}</td>
+                  </tr>
+                ))}
+
+                {!loading && movies.length === 0 ? (
+                  <tr>
+                    <td style={{ padding: "0.5rem" }} colSpan={4}>No movies found.</td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
     </section>
   );
 }
@@ -261,23 +467,6 @@ function CastingTab() {
       setError(e instanceof ApiError ? e.message : "Failed to save casting settings.");
     } finally {
       setSaving(false);
-    }
-  };
-
-  const onSaveMatching = async () => {
-    setMatchSaving(true);
-    setError(null);
-    try {
-      const minUsers = matchMinUsers.trim() ? Math.floor(Number(matchMinUsers)) : null;
-      const minUserPercent = matchMinUserPercent.trim() ? Math.floor(Number(matchMinUserPercent)) : null;
-      const updated = await adminUpdateMatchSettings("tmdb", "tmdb", { minUsers, minUserPercent });
-      setMatchSettings(updated);
-      setMatchMinUsers(updated.minUsers != null ? String(updated.minUsers) : "");
-      setMatchMinUserPercent(updated.minUserPercent != null ? String(updated.minUserPercent) : "");
-    } catch (e) {
-      setError(e instanceof ApiError ? e.message : "Failed to save matching settings.");
-    } finally {
-      setMatchSaving(false);
     }
   };
 
@@ -434,6 +623,9 @@ function RoomsTab() {
   const [lanHostPort, setLanHostPort] = useState("");
   const [wanHostPort, setWanHostPort] = useState("");
 
+	const [roomLifetimeMinutes, setRoomLifetimeMinutes] = useState("");
+	const [guestSessionLifetimeMinutes, setGuestSessionLifetimeMinutes] = useState("");
+
   const load = async () => {
     setLoading(true);
     setError(null);
@@ -442,6 +634,8 @@ function RoomsTab() {
       setSettings(s);
       setLanHostPort(s.lanHostPort ?? "");
       setWanHostPort(s.wanHostPort ?? "");
+		setRoomLifetimeMinutes(s.roomLifetimeMinutes != null ? String(s.roomLifetimeMinutes) : "");
+		setGuestSessionLifetimeMinutes(s.guestSessionLifetimeMinutes != null ? String(s.guestSessionLifetimeMinutes) : "");
     } catch (e) {
       setError(e instanceof ApiError ? e.message : "Failed to load room settings.");
     } finally {
@@ -458,9 +652,20 @@ function RoomsTab() {
     setSaving(true);
     setError(null);
     try {
+		const roomLifetime = roomLifetimeMinutes.trim() ? Number(roomLifetimeMinutes.trim()) : null;
+		const guestLifetime = guestSessionLifetimeMinutes.trim() ? Number(guestSessionLifetimeMinutes.trim()) : null;
+		if (roomLifetime !== null && (!Number.isFinite(roomLifetime) || roomLifetime <= 0)) {
+			throw new ApiError(400, "Room lifetime minutes must be blank or a number >= 1.");
+		}
+		if (guestLifetime !== null && (!Number.isFinite(guestLifetime) || guestLifetime <= 0)) {
+			throw new ApiError(400, "Guest session lifetime minutes must be blank or a number >= 1.");
+		}
+
       const updated = await adminUpdateJoinAddressSettings({
         lanHostPort: lanHostPort.trim() ? lanHostPort.trim() : null,
-        wanHostPort: wanHostPort.trim() ? wanHostPort.trim() : null
+			wanHostPort: wanHostPort.trim() ? wanHostPort.trim() : null,
+			roomLifetimeMinutes: roomLifetime,
+			guestSessionLifetimeMinutes: guestLifetime
       });
       setSettings(updated);
       await load();
@@ -499,6 +704,24 @@ function RoomsTab() {
           </div>
         </div>
 
+    <div style={{ marginTop: "1rem" }}>
+      <h3 style={{ marginTop: 0, marginBottom: "0.75rem" }}>Lifetimes</h3>
+      <div style={{ color: "#8c93a6", marginBottom: "0.75rem" }}>
+        Set how long rooms and guest sessions stay valid (minutes). Leave blank to use defaults.
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.75rem" }}>
+        <div>
+          <div style={{ color: "#8c93a6", fontWeight: 700, marginBottom: "0.25rem" }}>Room lifetime (minutes)</div>
+          <input className="input" value={roomLifetimeMinutes} onChange={(e) => setRoomLifetimeMinutes(e.target.value)} placeholder="120" inputMode="numeric" />
+        </div>
+        <div>
+          <div style={{ color: "#8c93a6", fontWeight: 700, marginBottom: "0.25rem" }}>Guest session lifetime (minutes)</div>
+          <input className="input" value={guestSessionLifetimeMinutes} onChange={(e) => setGuestSessionLifetimeMinutes(e.target.value)} placeholder="60" inputMode="numeric" />
+        </div>
+      </div>
+    </div>
+
         <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem", alignItems: "center", flexWrap: "wrap" }}>
           <button type="button" className="pill pill--neutral is-on" onClick={() => void onSave()} disabled={loading || saving}>
             Save
@@ -525,6 +748,8 @@ function TmdbTab() {
   const [maxMovies, setMaxMovies] = useState("20000");
   const [imageCacheMaxMb, setImageCacheMaxMb] = useState("512");
   const [posterMode, setPosterMode] = useState("Tmdb");
+  const [prewarmOriginalLanguage, setPrewarmOriginalLanguage] = useState("");
+  const [prewarmRegion, setPrewarmRegion] = useState("");
 
   const [moviesLoading, setMoviesLoading] = useState(false);
   const [moviesError, setMoviesError] = useState<string | null>(null);
@@ -558,6 +783,8 @@ function TmdbTab() {
       setMaxMovies(String(s.maxMovies));
       setImageCacheMaxMb(String(s.imageCacheMaxMb));
       setPosterMode(String(s.posterMode || "Tmdb"));
+      setPrewarmOriginalLanguage(s.prewarmOriginalLanguage ?? "");
+      setPrewarmRegion(s.prewarmRegion ?? "");
 
 		try {
 			const m = await adminGetMatchSettings("tmdb", "tmdb");
@@ -671,13 +898,17 @@ function TmdbTab() {
         maxRows: parsed,
         maxMovies: parsedMaxMovies,
         imageCacheMaxMb: parsedImageMax,
-        posterMode
+        posterMode,
+        prewarmOriginalLanguage: prewarmOriginalLanguage.trim() ? prewarmOriginalLanguage.trim() : null,
+        prewarmRegion: prewarmRegion.trim() ? prewarmRegion.trim() : null
       });
       setSettings(updated);
       setMaxRows(String(updated.maxRows));
       setMaxMovies(String(updated.maxMovies));
       setImageCacheMaxMb(String(updated.imageCacheMaxMb));
       setPosterMode(String(updated.posterMode || "Tmdb"));
+      setPrewarmOriginalLanguage(updated.prewarmOriginalLanguage ?? "");
+      setPrewarmRegion(updated.prewarmRegion ?? "");
     } catch (e) {
       const msg = e instanceof ApiError ? e.message : "Failed to update TMDB cache settings.";
       setError(msg);
@@ -690,8 +921,13 @@ function TmdbTab() {
 		setMatchSaving(true);
 		setError(null);
 		try {
-			const minUsers = matchMinUsers.trim() ? Math.floor(Number(matchMinUsers)) : null;
-			const minUserPercent = matchMinUserPercent.trim() ? Math.floor(Number(matchMinUserPercent)) : null;
+      const minUsers = matchMinUsers.trim() ? Math.floor(Number(matchMinUsers)) : null;
+      const minUserPercent = matchMinUserPercent.trim() ? Math.floor(Number(matchMinUserPercent)) : null;
+      if (minUsers === 0)
+      {
+        setError("Min users must be blank or between 1 and 50.");
+        return;
+      }
 			const updated = await adminUpdateMatchSettings("tmdb", "tmdb", { minUsers, minUserPercent });
 			setMatchSettings(updated);
 			setMatchMinUsers(updated.minUsers != null ? String(updated.minUsers) : "");
@@ -887,6 +1123,40 @@ function TmdbTab() {
                 <option value="LocalProxy">Cache images locally (proxy)</option>
               </select>
             </label>
+
+            <label style={{ display: "grid", gap: "0.25rem" }}>
+              <span>Prewarm original language</span>
+              <input
+                className="input"
+                value={prewarmOriginalLanguage}
+                onChange={(e) => setPrewarmOriginalLanguage(e.target.value)}
+                placeholder="(use user preferences)"
+                list="tmdb_prewarm_language"
+              />
+            </label>
+
+            <label style={{ display: "grid", gap: "0.25rem" }}>
+              <span>Prewarm region</span>
+              <input
+                className="input"
+                value={prewarmRegion}
+                onChange={(e) => setPrewarmRegion(e.target.value)}
+                placeholder="(use user preferences)"
+                list="tmdb_prewarm_region"
+              />
+            </label>
+
+            <datalist id="tmdb_prewarm_language">
+              {TMDB_LANGUAGES.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </datalist>
+
+            <datalist id="tmdb_prewarm_region">
+              {TMDB_REGIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </datalist>
 
             <label style={{ display: "grid", gap: "0.25rem" }}>
               <span>Max image cache (MB)</span>
@@ -2060,6 +2330,11 @@ function RadarrTab() {
       const sid = serverId.trim() || "default";
       const minUsers = matchMinUsers.trim() ? Math.floor(Number(matchMinUsers)) : null;
       const minUserPercent = matchMinUserPercent.trim() ? Math.floor(Number(matchMinUserPercent)) : null;
+			if (minUsers === 0)
+			{
+				setError("Min users must be blank or between 1 and 50.");
+				return;
+			}
       const updated = await adminUpdateMatchSettings("radarr", sid, { minUsers, minUserPercent });
       setMatchSettings(updated);
       setMatchMinUsers(updated.minUsers != null ? String(updated.minUsers) : "");

--- a/ui/src/pages/AdminConsolePage.tsx
+++ b/ui/src/pages/AdminConsolePage.tsx
@@ -94,6 +94,10 @@ type AppRole = "Admin" | "Curator" | "Contributor";
 
 const ROLE_ORDER: AppRole[] = ["Admin", "Curator", "Contributor"];
 
+const MATCH_MIN_USERS_MIN = 1;
+const MATCH_MIN_USERS_MAX = 50;
+const MATCH_MIN_USERS_ERROR = `Min users must be blank or between ${MATCH_MIN_USERS_MIN} and ${MATCH_MIN_USERS_MAX}.`;
+
 function getPrimaryRole(roles: string[]): AppRole {
   for (const r of ROLE_ORDER) {
     if (roles.includes(r)) return r;
@@ -655,10 +659,10 @@ function RoomsTab() {
 		const roomLifetime = roomLifetimeMinutes.trim() ? Number(roomLifetimeMinutes.trim()) : null;
 		const guestLifetime = guestSessionLifetimeMinutes.trim() ? Number(guestSessionLifetimeMinutes.trim()) : null;
 		if (roomLifetime !== null && (!Number.isFinite(roomLifetime) || roomLifetime <= 0)) {
-			throw new ApiError(400, "Room lifetime minutes must be blank or a number >= 1.");
+        throw new ApiError("Room lifetime minutes must be blank or a number >= 1.", 400, null);
 		}
 		if (guestLifetime !== null && (!Number.isFinite(guestLifetime) || guestLifetime <= 0)) {
-			throw new ApiError(400, "Guest session lifetime minutes must be blank or a number >= 1.");
+        throw new ApiError("Guest session lifetime minutes must be blank or a number >= 1.", 400, null);
 		}
 
       const updated = await adminUpdateJoinAddressSettings({
@@ -923,9 +927,8 @@ function TmdbTab() {
 		try {
       const minUsers = matchMinUsers.trim() ? Math.floor(Number(matchMinUsers)) : null;
       const minUserPercent = matchMinUserPercent.trim() ? Math.floor(Number(matchMinUserPercent)) : null;
-      if (minUsers === 0)
-      {
-        setError("Min users must be blank or between 1 and 50.");
+      if (minUsers !== null && (Number.isNaN(minUsers) || minUsers < MATCH_MIN_USERS_MIN || minUsers > MATCH_MIN_USERS_MAX)) {
+        setError(MATCH_MIN_USERS_ERROR);
         return;
       }
 			const updated = await adminUpdateMatchSettings("tmdb", "tmdb", { minUsers, minUserPercent });
@@ -2330,9 +2333,8 @@ function RadarrTab() {
       const sid = serverId.trim() || "default";
       const minUsers = matchMinUsers.trim() ? Math.floor(Number(matchMinUsers)) : null;
       const minUserPercent = matchMinUserPercent.trim() ? Math.floor(Number(matchMinUserPercent)) : null;
-			if (minUsers === 0)
-			{
-				setError("Min users must be blank or between 1 and 50.");
+			if (minUsers !== null && (Number.isNaN(minUsers) || minUsers < MATCH_MIN_USERS_MIN || minUsers > MATCH_MIN_USERS_MAX)) {
+				setError(MATCH_MIN_USERS_ERROR);
 				return;
 			}
       const updated = await adminUpdateMatchSettings("radarr", sid, { minUsers, minUserPercent });

--- a/ui/src/pages/RoomPage.tsx
+++ b/ui/src/pages/RoomPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import QRCode from "qrcode";
 import SwipeCardComponent from "../components/SwipeCard";
@@ -9,6 +9,10 @@ import type { CastDeviceDto, RoomJoinUrlResponse, RoomMatchesResponse, RoomState
 import { ApiError } from "../api/http";
 import { useAuth } from "../auth/AuthContext";
 import type { SwipeAction, SwipeCard } from "../types";
+
+const PREFETCH_THRESHOLD = 2;
+const PREFETCH_LIMIT = 10;
+const PREFETCH_EMPTY_RETRIES = 2;
 
 export default function RoomPage() {
   const { user, loading: authLoading, guestLogin } = useAuth();
@@ -34,6 +38,8 @@ export default function RoomPage() {
   const [deckLoading, setDeckLoading] = useState(false);
   const [leaving, setLeaving] = useState<{ card: SwipeCard; action: SwipeAction; fromOffset?: { x: number; y: number } } | null>(null);
   const [selectedTmdbId, setSelectedTmdbId] = useState<number | null>(null);
+
+  const prefetchInFlightRef = useRef(false);
 
   useEffect(() => {
     function handleScopeUpdated() {
@@ -159,10 +165,69 @@ export default function RoomPage() {
     }
   }, [room, user]);
 
+  const appendUniqueCards = useCallback((incoming: SwipeCard[]) => {
+    if (!incoming.length) return;
+    setCards((prev) => {
+      if (!prev.length) return incoming;
+      const existing = new Set(prev.map((c) => c.tmdbId));
+      const deduped = incoming.filter((c) => !existing.has(c.tmdbId));
+      return deduped.length ? [...prev, ...deduped] : prev;
+    });
+  }, []);
+
+  const prefetchMoreCards = useCallback(async () => {
+    if (!room) return;
+    if (!user) return;
+    if (deckLoading) return;
+    if (error) return;
+    if (prefetchInFlightRef.current) return;
+
+    prefetchInFlightRef.current = true;
+    try {
+      for (let attempt = 0; attempt <= PREFETCH_EMPTY_RETRIES; attempt++) {
+        try {
+          const response = await fetchRoomSwipeDeck(room.roomId, PREFETCH_LIMIT);
+          if (response.items.length > 0) {
+            appendUniqueCards(response.items);
+            break;
+          }
+        } catch (e) {
+          // Backward-compat: older APIs won't have /rooms/{id}/swipedeck yet.
+          if (e instanceof ApiError && e.status === 404) {
+            const response = await fetchSwipeDeck(PREFETCH_LIMIT, room.serviceType, room.serverId);
+            if (response.items.length > 0) {
+              appendUniqueCards(response.items);
+              break;
+            }
+          } else {
+            throw e;
+          }
+        }
+
+        if (attempt !== PREFETCH_EMPTY_RETRIES) {
+          await sleep(250 * (attempt + 1));
+        }
+      }
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(e.message);
+      } else {
+        setError("Failed to load room swipedeck.");
+      }
+    } finally {
+      prefetchInFlightRef.current = false;
+    }
+  }, [appendUniqueCards, deckLoading, error, room, user]);
+
   useEffect(() => {
     if (!room) return;
     void loadDeck();
   }, [loadDeck, room]);
+
+  useEffect(() => {
+    if (cards.length >= PREFETCH_THRESHOLD) return;
+    void prefetchMoreCards();
+  }, [cards.length, prefetchMoreCards]);
 
   const requestSwipe = useCallback(
     (action: SwipeAction, fromOffset?: { x: number; y: number }) => {
@@ -290,7 +355,7 @@ export default function RoomPage() {
     setError(null);
     setLoading(true);
     try {
-      await guestLogin();
+      await guestLogin(roomId);
       // Reload effect will join+load.
     } catch (e) {
       if (e instanceof ApiError) {

--- a/ui/src/pages/SwipeDeckPage.tsx
+++ b/ui/src/pages/SwipeDeckPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import SwipeCardComponent from "../components/SwipeCard";
 import MovieDetailsModal from "../components/MovieDetailsModal";
@@ -9,6 +9,10 @@ import { isMobileDevice } from "../device";
 import { useAuth } from "../auth/AuthContext";
 import { hasCompletedSwipeTutorial, setSwipeTutorialCompleted } from "../onboarding/swipeTutorial";
 import type { SwipeAction, SwipeCard } from "../types";
+
+const PREFETCH_THRESHOLD = 2;
+const PREFETCH_LIMIT = 10;
+const PREFETCH_EMPTY_RETRIES = 2;
 
 const ACTION_LABELS: Record<SwipeAction, string> = {
   Like: "Like",
@@ -51,6 +55,8 @@ export default function SwipeDeckPage() {
   const [tutorialHistory, setTutorialHistory] = useState<Array<{ card: SwipeCard; action: SwipeAction }>>([]);
   const [tutorialNote, setTutorialNote] = useState<string | null>(null);
 
+  const prefetchInFlightRef = useRef(false);
+
   const activeCard = cards[0];
 
   const loadDeck = useCallback(async () => {
@@ -80,6 +86,45 @@ export default function SwipeDeckPage() {
       setLoading(false);
     }
   }, []);
+
+  const appendUniqueCards = useCallback((incoming: SwipeCard[]) => {
+    if (!incoming.length) return;
+    setCards((prev) => {
+      if (!prev.length) return incoming;
+      const existing = new Set(prev.map((c) => c.tmdbId));
+      const deduped = incoming.filter((c) => !existing.has(c.tmdbId));
+      return deduped.length ? [...prev, ...deduped] : prev;
+    });
+  }, []);
+
+  const prefetchMoreCards = useCallback(async () => {
+    if (prefetchInFlightRef.current) return;
+    if (loading) return;
+    if (error) return;
+
+    prefetchInFlightRef.current = true;
+    try {
+      for (let attempt = 0; attempt <= PREFETCH_EMPTY_RETRIES; attempt++) {
+        const response = await fetchSwipeDeck(PREFETCH_LIMIT);
+        if (response.items.length > 0) {
+          appendUniqueCards(response.items);
+          break;
+        }
+
+        if (attempt !== PREFETCH_EMPTY_RETRIES) {
+          await sleep(250 * (attempt + 1));
+        }
+      }
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        setError("You’re not logged in. Please login and try again.");
+      } else {
+        setError(err instanceof Error ? err.message : "Failed to load swipedeck");
+      }
+    } finally {
+      prefetchInFlightRef.current = false;
+    }
+  }, [appendUniqueCards, error, loading]);
 
   const requestSwipe = useCallback(
     (action: SwipeAction, fromOffset?: { x: number; y: number }) => {
@@ -230,6 +275,12 @@ export default function SwipeDeckPage() {
   useEffect(() => {
     loadDeck();
   }, [loadDeck]);
+
+  // When the deck is running low, poll for more cards and append them to the bottom.
+  useEffect(() => {
+    if (cards.length >= PREFETCH_THRESHOLD) return;
+    void prefetchMoreCards();
+  }, [cards.length, prefetchMoreCards]);
 
   // In tutorial mode we don't persist swipes, so the server deck can still be full while the local deck drains.
   // Auto-refresh to keep the tutorial moving.


### PR DESCRIPTION
Summary:
- Adds join address settings for room/guest lifetime
- Updates TMDB cache settings + related API/UI wiring

Notes:
- Includes DB migration for JoinAddressSettings changes

## Summary by Sourcery

Add configurable room and guest lifetimes, improve TMDB cache configuration and prewarming behaviour, and enhance swipe deck and background processing flows.

New Features:
- Allow admins to configure room and guest session lifetimes via join address settings and apply them to room expiry and guest JWT lifetimes.
- Introduce admin DB movies view with pagination and gallery/table modes for inspecting TMDB metadata per service scope.
- Support TMDB cache prewarm language and region configuration and apply them to discovery, prewarm workers, and deck generation.
- Enable per-room guest login tokens and guest-only room access control based on JWT claims.

Bug Fixes:
- Ensure only privileged users both initiate and enqueue Radarr superlike actions when swiping.
- Allow guest identities to be resolved from access tokens for /auth/me without requiring persistence.

Enhancements:
- Refine TMDB metadata storage and discovery to use a shared pool, add deck candidate listing, and broaden details/image backfill for discovered movies.
- Add swipe deck card prefetching in room and standalone decks to reduce stalls while avoiding duplicate cards.
- Adjust Radarr superlike background worker to schedule runs based on pending work and improve error handling.
- Improve match computation thresholds and validation for TMDB and Radarr to handle legacy zero min-users settings more safely.
- Allow configuration of TMDB metadata DB path for both API and worker services for consistent storage.

Tests:
- Update test fakes for library cache repositories to match new counting and listing interfaces.