### PR TITLE
Add Google Cast SDK support and casting fallback

### DIFF
--- a/build/scripts/dev.ps1
+++ b/build/scripts/dev.ps1
@@ -211,6 +211,7 @@ if ($lanIp) {
 try {
 	if (-not $UiOnly) {
 		$apiProc = Start-Api -repoRoot $repoRoot -listenUrl $listenUrl -environment $Environment -lanBaseUrl $lanBaseUrl
+		Start-Sleep -Seconds 5
 		$workersProc = Start-Workers -repoRoot $repoRoot -environment $Environment -lanBaseUrl $lanBaseUrl
 	}
 

--- a/docs/architecture/playback-gateway.md
+++ b/docs/architecture/playback-gateway.md
@@ -3,9 +3,9 @@
 
 This document describes how Tindarr proxies and secures media playback so that:
 
-- Clients never talk directly to Plex/Jellyfin/Emby.
-- Cast devices only ever fetch media from Tindarr URLs.
-- Provider credentials never appear in URLs (only in upstream request headers).
+- Playback can be proxied through Tindarr when needed (tokenized gateway URLs).
+- Casting prefers direct media-server URLs when possible (cast devices fetch from Plex/Jellyfin/Emby directly).
+- When direct casting isn't possible, casting falls back to the Tindarr playback gateway.
 
 See also: `docs/architecture/invariants.md`.
 

--- a/src/Tindarr.Api/Controllers/CastingController.cs
+++ b/src/Tindarr.Api/Controllers/CastingController.cs
@@ -26,6 +26,7 @@ public sealed class CastingController(
 	ICastClient castClient,
 	ICastUrlTokenService castUrlTokenService,
 	IPlaybackTokenService playbackTokenService,
+	IEnumerable<IPlaybackProvider> playbackProviders,
 	IRoomService roomService,
 	IBaseUrlResolver baseUrlResolver,
 	IJoinAddressSettingsRepository joinAddressSettings,
@@ -127,6 +128,45 @@ public sealed class CastingController(
 		return Ok();
 	}
 
+	[HttpGet("rooms/{roomId}/qr/cast-url")]
+	[Authorize]
+	public async Task<ActionResult<CastMediaUrlDto>> GetRoomQrCastUrl(
+		[FromRoute] string roomId,
+		CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(roomId))
+		{
+			return BadRequest("Room id is required.");
+		}
+
+		var room = await roomService.GetAsync(roomId, cancellationToken).ConfigureAwait(false);
+		if (room is null)
+		{
+			return NotFound("Room not found.");
+		}
+
+		var baseUri = await ResolveCastFetchBaseUriAsync(cancellationToken).ConfigureAwait(false);
+		if (baseUri is null)
+		{
+			return BadRequest("LAN cast base URL is not configured. Ask an admin to set LAN join address in Admin Console or configure 'BaseUrl:Lan'.");
+		}
+
+		if (!IsServerListeningOnNonLoopback())
+		{
+			return BadRequest("API is only listening on localhost. Chromecast cannot reach it. Start the API with '--urls http://0.0.0.0:<port>' (or bind to your LAN IP) and allow the port through Windows Firewall.");
+		}
+
+		var token = castUrlTokenService.IssueRoomQrToken(roomId, DateTimeOffset.UtcNow);
+		var qrUrl = new Uri(baseUri, $"api/v1/casting/rooms/{Uri.EscapeDataString(roomId)}/qr.png?token={Uri.EscapeDataString(token)}");
+		Response.Headers["X-Tindarr-Cast-Url"] = qrUrl.ToString();
+
+		return Ok(new CastMediaUrlDto(
+			Url: qrUrl.ToString(),
+			ContentType: "image/png",
+			Title: "Join room",
+			SubTitle: roomId));
+	}
+
 	[HttpPost("movie")]
 	[Authorize]
 	public async Task<IActionResult> CastMovie([FromBody] CastMovieRequest request, CancellationToken cancellationToken)
@@ -146,6 +186,18 @@ public sealed class CastingController(
 		}
 
 		var title = string.IsNullOrWhiteSpace(request.Title) ? $"TMDB:{request.TmdbId}" : request.Title.Trim();
+
+		var directUrl = await TryBuildDirectMovieCastUrlAsync(scope, request.TmdbId, cancellationToken).ConfigureAwait(false);
+		if (directUrl is not null)
+		{
+			logger.LogInformation("Casting movie to device {DeviceId} via direct {ServiceType} URL.", request.DeviceId, scope.ServiceType);
+			await castClient.CastAsync(request.DeviceId, new CastMedia(
+				ContentUrl: directUrl.ToString(),
+				ContentType: "video/mp4",
+				Title: title,
+				SubTitle: scope.ServiceType.ToString()), cancellationToken).ConfigureAwait(false);
+			return Ok();
+		}
 
 		var baseUri = await ResolveCastFetchBaseUriAsync(cancellationToken).ConfigureAwait(false);
 		if (baseUri is null)
@@ -167,21 +219,92 @@ public sealed class CastingController(
 			return BadRequest("API is only listening on localhost. Chromecast cannot reach it. Start the API with '--urls http://0.0.0.0:<port>' (or bind to your LAN IP) and allow the port through Windows Firewall.");
 		}
 
-		try
+		await castClient.CastAsync(request.DeviceId, new CastMedia(
+			ContentUrl: playbackUrl.ToString(),
+			ContentType: "video/mp4",
+			Title: title,
+			SubTitle: scope.ServiceType.ToString()), cancellationToken).ConfigureAwait(false);
+
+		return Ok();
+	}
+
+	[HttpPost("movie/cast-url")]
+	[Authorize]
+	public async Task<ActionResult<CastMediaUrlDto>> GetMovieCastUrl([FromBody] GetMovieCastUrlRequest request, CancellationToken cancellationToken)
+	{
+		if (request.TmdbId <= 0)
 		{
-			await castClient.CastAsync(request.DeviceId, new CastMedia(
-				ContentUrl: playbackUrl.ToString(),
+			return BadRequest("TmdbId must be positive.");
+		}
+
+		if (!ServiceScope.TryCreate(request.ServiceType, request.ServerId, out var scope) || scope is null)
+		{
+			return BadRequest("ServiceType and ServerId are required.");
+		}
+
+		var title = string.IsNullOrWhiteSpace(request.Title) ? $"TMDB:{request.TmdbId}" : request.Title.Trim();
+
+		var directUrl = await TryBuildDirectMovieCastUrlAsync(scope, request.TmdbId, cancellationToken).ConfigureAwait(false);
+		if (directUrl is not null)
+		{
+			return Ok(new CastMediaUrlDto(
+				Url: directUrl.ToString(),
 				ContentType: "video/mp4",
 				Title: title,
-				SubTitle: scope.ServiceType.ToString()), cancellationToken).ConfigureAwait(false);
+				SubTitle: scope.ServiceType.ToString()));
+		}
+
+		var baseUri = await ResolveCastFetchBaseUriAsync(cancellationToken).ConfigureAwait(false);
+		if (baseUri is null)
+		{
+			return BadRequest("LAN cast base URL is not configured. Ask an admin to set LAN join address in Admin Console or configure 'BaseUrl:Lan'.");
+		}
+
+		if (!IsServerListeningOnNonLoopback())
+		{
+			return BadRequest("API is only listening on localhost. Chromecast cannot reach it. Start the API with '--urls http://0.0.0.0:<port>' (or bind to your LAN IP) and allow the port through Windows Firewall.");
+		}
+
+		var token = playbackTokenService.IssueMovieToken(scope, request.TmdbId, DateTimeOffset.UtcNow);
+		var playbackUrl = new Uri(baseUri, $"api/v1/playback/movie/{Uri.EscapeDataString(scope.ServiceType.ToString().ToLowerInvariant())}/{Uri.EscapeDataString(scope.ServerId)}/{request.TmdbId}?token={Uri.EscapeDataString(token)}");
+		Response.Headers["X-Tindarr-Cast-Url"] = playbackUrl.ToString();
+
+		return Ok(new CastMediaUrlDto(
+			Url: playbackUrl.ToString(),
+			ContentType: "video/mp4",
+			Title: title,
+			SubTitle: scope.ServiceType.ToString()));
+	}
+
+	private async Task<Uri?> TryBuildDirectMovieCastUrlAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
+	{
+		var provider = playbackProviders.FirstOrDefault(p => p.ServiceType == scope.ServiceType);
+		if (provider is not IDirectPlaybackProvider direct)
+		{
+			return null;
+		}
+
+		try
+		{
+			var uri = await direct.TryBuildDirectMovieStreamUrlAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+			if (uri is null)
+			{
+				return null;
+			}
+
+			// If upstream is configured as localhost/loopback, Chromecast won't be able to reach it.
+			if (IsLoopbackHost(uri.Host))
+			{
+				return null;
+			}
+
+			return uri;
 		}
 		catch (Exception ex)
 		{
-			logger.LogWarning(ex, "cast movie failed");
-			throw;
+			logger.LogDebug(ex, "Failed to build direct movie stream URL; falling back to playback gateway. ServiceType={ServiceType} ServerId={ServerId} TmdbId={TmdbId}", scope.ServiceType, scope.ServerId, tmdbId);
+			return null;
 		}
-
-		return Ok();
 	}
 
 	private async Task<string?> BuildJoinUrlAsync(string roomId, CancellationToken cancellationToken)

--- a/src/Tindarr.Api/Controllers/InteractionsController.cs
+++ b/src/Tindarr.Api/Controllers/InteractionsController.cs
@@ -120,6 +120,22 @@ public sealed class InteractionsController(
 		return Ok(new UndoResponse(true, interaction.TmdbId, MapAction(interaction.Action), interaction.CreatedAtUtc));
 	}
 
+	[HttpDelete]
+	public async Task<IActionResult> ClearHistory(
+		[FromQuery] string serviceType,
+		[FromQuery] string serverId,
+		CancellationToken cancellationToken)
+	{
+		if (!ServiceScope.TryCreate(serviceType, serverId, out var scope))
+		{
+			return BadRequest("ServiceType and ServerId are required.");
+		}
+
+		var userId = User.GetUserId();
+		await interactionService.ClearHistoryAsync(userId, scope!, cancellationToken);
+		return NoContent();
+	}
+
 	private static InteractionAction MapAction(SwipeActionDto action)
 	{
 		return action switch

--- a/src/Tindarr.Api/Controllers/InteractionsController.cs
+++ b/src/Tindarr.Api/Controllers/InteractionsController.cs
@@ -120,6 +120,7 @@ public sealed class InteractionsController(
 		return Ok(new UndoResponse(true, interaction.TmdbId, MapAction(interaction.Action), interaction.CreatedAtUtc));
 	}
 
+	[Authorize]
 	[HttpDelete]
 	public async Task<IActionResult> ClearHistory(
 		[FromQuery] string serviceType,

--- a/src/Tindarr.Application/Abstractions/Persistence/IPlexLibraryCacheRepository.cs
+++ b/src/Tindarr.Application/Abstractions/Persistence/IPlexLibraryCacheRepository.cs
@@ -17,6 +17,14 @@ public interface IPlexLibraryCacheRepository
 
 	Task ReplaceItemsAsync(ServiceScope scope, IReadOnlyCollection<PlexLibraryItem> items, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken);
 
+	/// <summary>
+	/// Incrementally syncs the cached Plex library items for a server.
+	/// - Adds new TMDB IDs found in the Plex response
+	/// - Updates existing rows if title/ratingKey changed
+	/// - Deletes rows whose TMDB IDs are no longer present in the Plex response
+	/// </summary>
+	Task SyncItemsAsync(ServiceScope scope, IReadOnlyCollection<PlexLibraryItem> items, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken);
+
 	Task AddTmdbIdsAsync(ServiceScope scope, IReadOnlyCollection<int> tmdbIds, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken);
 
 	Task RemoveTmdbIdsAsync(ServiceScope scope, IReadOnlyCollection<int> tmdbIds, CancellationToken cancellationToken);

--- a/src/Tindarr.Application/Features/Interactions/InteractionService.cs
+++ b/src/Tindarr.Application/Features/Interactions/InteractionService.cs
@@ -18,6 +18,11 @@ public sealed class InteractionService(IInteractionStore store) : IInteractionSe
         return store.UndoLastAsync(userId, scope, cancellationToken);
     }
 
+	public Task ClearHistoryAsync(string userId, ServiceScope scope, CancellationToken cancellationToken)
+	{
+		return store.ClearHistoryAsync(userId, scope, cancellationToken);
+	}
+
     public Task<IReadOnlyList<Interaction>> ListAsync(
         string userId,
         ServiceScope scope,

--- a/src/Tindarr.Application/Features/Plex/PlexService.cs
+++ b/src/Tindarr.Application/Features/Plex/PlexService.cs
@@ -222,7 +222,7 @@ public sealed class PlexService(
 		}
 
 		var now = DateTimeOffset.UtcNow;
-		await plexLibraryCache.ReplaceItemsAsync(scope, libraryItems, now, cancellationToken).ConfigureAwait(false);
+		await plexLibraryCache.SyncItemsAsync(scope, libraryItems, now, cancellationToken).ConfigureAwait(false);
 		await UpdateServerAsync(settings, plexLastLibrarySyncUtc: now, cancellationToken: cancellationToken).ConfigureAwait(false);
 
 		// Seed local TMDB metadata store with IDs/titles from Plex.

--- a/src/Tindarr.Application/Interfaces/Interactions/IInteractionService.cs
+++ b/src/Tindarr.Application/Interfaces/Interactions/IInteractionService.cs
@@ -7,6 +7,7 @@ public interface IInteractionService
 {
     Task<Interaction> AddAsync(string userId, ServiceScope scope, int tmdbId, InteractionAction action, CancellationToken cancellationToken);
     Task<Interaction?> UndoLastAsync(string userId, ServiceScope scope, CancellationToken cancellationToken);
+    Task ClearHistoryAsync(string userId, ServiceScope scope, CancellationToken cancellationToken);
     Task<IReadOnlyList<Interaction>> ListAsync(
         string userId,
         ServiceScope scope,

--- a/src/Tindarr.Application/Interfaces/Interactions/IInteractionStore.cs
+++ b/src/Tindarr.Application/Interfaces/Interactions/IInteractionStore.cs
@@ -7,6 +7,7 @@ public interface IInteractionStore
 {
     Task AddAsync(Interaction interaction, CancellationToken cancellationToken);
     Task<Interaction?> UndoLastAsync(string userId, ServiceScope scope, CancellationToken cancellationToken);
+    Task ClearHistoryAsync(string userId, ServiceScope scope, CancellationToken cancellationToken);
     Task<IReadOnlyCollection<int>> GetInteractedTmdbIdsAsync(string userId, ServiceScope scope, CancellationToken cancellationToken);
     Task<IReadOnlyList<Interaction>> ListAsync(
         string userId,

--- a/src/Tindarr.Application/Interfaces/Playback/IPlaybackProvider.cs
+++ b/src/Tindarr.Application/Interfaces/Playback/IPlaybackProvider.cs
@@ -13,6 +13,16 @@ public interface IPlaybackProvider
 	Task<UpstreamPlaybackRequest> BuildMovieStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken);
 }
 
+/// <summary>
+/// Optional extension for providers that can generate a direct-play URL suitable for cast devices.
+/// Cast devices generally cannot send custom auth headers, so providers implementing this interface
+/// must embed any required auth in the returned URL (e.g. querystring token).
+/// </summary>
+public interface IDirectPlaybackProvider : IPlaybackProvider
+{
+	Task<Uri?> TryBuildDirectMovieStreamUrlAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken);
+}
+
 public sealed record UpstreamPlaybackRequest(
 	Uri Uri,
 	IReadOnlyDictionary<string, string> Headers);

--- a/src/Tindarr.Contracts/Casting/CastMediaUrlDto.cs
+++ b/src/Tindarr.Contracts/Casting/CastMediaUrlDto.cs
@@ -1,0 +1,7 @@
+namespace Tindarr.Contracts.Casting;
+
+public sealed record CastMediaUrlDto(
+	string Url,
+	string ContentType,
+	string Title,
+	string? SubTitle);

--- a/src/Tindarr.Contracts/Casting/GetMovieCastUrlRequest.cs
+++ b/src/Tindarr.Contracts/Casting/GetMovieCastUrlRequest.cs
@@ -1,0 +1,7 @@
+namespace Tindarr.Contracts.Casting;
+
+public sealed record GetMovieCastUrlRequest(
+	string ServiceType,
+	string ServerId,
+	int TmdbId,
+	string? Title);

--- a/src/Tindarr.Infrastructure/Interactions/EfCoreInteractionStore.cs
+++ b/src/Tindarr.Infrastructure/Interactions/EfCoreInteractionStore.cs
@@ -49,6 +49,13 @@ public sealed class EfCoreInteractionStore(TindarrDbContext db) : IInteractionSt
 			last.CreatedAtUtc);
 	}
 
+	public async Task ClearHistoryAsync(string userId, ServiceScope scope, CancellationToken cancellationToken)
+	{
+		await db.Interactions
+			.Where(x => x.UserId == userId && x.ServiceType == scope.ServiceType && x.ServerId == scope.ServerId)
+			.ExecuteDeleteAsync(cancellationToken);
+	}
+
 	public async Task<IReadOnlyCollection<int>> GetInteractedTmdbIdsAsync(string userId, ServiceScope scope, CancellationToken cancellationToken)
 	{
 		// We keep this as a distinct list to avoid pulling unnecessary rows into memory.

--- a/src/Tindarr.Infrastructure/Interactions/InMemoryInteractionStore.cs
+++ b/src/Tindarr.Infrastructure/Interactions/InMemoryInteractionStore.cs
@@ -56,6 +56,13 @@ public sealed class InMemoryInteractionStore : IInteractionStore
         }
     }
 
+    public Task ClearHistoryAsync(string userId, ServiceScope scope, CancellationToken cancellationToken)
+    {
+        var key = BuildKey(userId, scope);
+        _interactions.TryRemove(key, out _);
+        return Task.CompletedTask;
+    }
+
     public Task<IReadOnlyCollection<int>> GetInteractedTmdbIdsAsync(string userId, ServiceScope scope, CancellationToken cancellationToken)
     {
         var key = BuildKey(userId, scope);

--- a/src/Tindarr.Infrastructure/Interactions/RoutingInteractionStore.cs
+++ b/src/Tindarr.Infrastructure/Interactions/RoutingInteractionStore.cs
@@ -34,6 +34,11 @@ public sealed class RoutingInteractionStore(
 		return Resolve(scope).UndoLastAsync(userId, scope, cancellationToken);
 	}
 
+	public Task ClearHistoryAsync(string userId, ServiceScope scope, CancellationToken cancellationToken)
+	{
+		return Resolve(scope).ClearHistoryAsync(userId, scope, cancellationToken);
+	}
+
 	public Task<IReadOnlyCollection<int>> GetInteractedTmdbIdsAsync(string userId, ServiceScope scope, CancellationToken cancellationToken)
 	{
 		return Resolve(scope).GetInteractedTmdbIdsAsync(userId, scope, cancellationToken);

--- a/src/Tindarr.Infrastructure/Persistence/Repositories/RadarrPendingAddRepository.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Repositories/RadarrPendingAddRepository.cs
@@ -20,7 +20,7 @@ public sealed class RadarrPendingAddRepository(TindarrDbContext db) : IRadarrPen
 				.FirstOrDefaultAsync(cancellationToken)
 				.ConfigureAwait(false);
 		}
-		catch (InvalidOperationException)
+		catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException)
 		{
 			// SQLite provider can have limited DateTimeOffset translation support in LINQ.
 			// Fall back to an in-memory min to avoid runtime translation exceptions.

--- a/src/Tindarr.Infrastructure/Playback/Providers/EmbyPlaybackProvider.cs
+++ b/src/Tindarr.Infrastructure/Playback/Providers/EmbyPlaybackProvider.cs
@@ -12,11 +12,22 @@ public sealed class EmbyPlaybackProvider(
 	IServiceSettingsRepository settingsRepo,
 	ICastingSettingsRepository castingSettingsRepo,
 	HttpClient httpClient,
-	ILogger<EmbyPlaybackProvider> logger) : IPlaybackProvider
+	ILogger<EmbyPlaybackProvider> logger) : IDirectPlaybackProvider
 {
 	private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
 
 	public ServiceType ServiceType => ServiceType.Emby;
+
+	public async Task<Uri?> TryBuildDirectMovieStreamUrlAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
+	{
+		var upstream = await BuildMovieStreamRequestAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+		if (!upstream.Headers.TryGetValue("X-Emby-Token", out var token) || string.IsNullOrWhiteSpace(token))
+		{
+			return null;
+		}
+
+		return AppendOrReplaceQuery(upstream.Uri, "api_key", token);
+	}
 
 	public async Task<UpstreamPlaybackRequest> BuildMovieStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
 	{
@@ -65,6 +76,55 @@ public sealed class EmbyPlaybackProvider(
 			{
 				["X-Emby-Token"] = apiKey
 			});
+	}
+
+	private static Uri AppendOrReplaceQuery(Uri uri, string key, string value)
+	{
+		var builder = new UriBuilder(uri);
+		var all = ParseQuery(builder.Query);
+
+		all[key] = value;
+		builder.Query = string.Join("&", all.Select(kvp => $"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(kvp.Value)}"));
+		return builder.Uri;
+	}
+
+	private static Dictionary<string, string> ParseQuery(string? query)
+	{
+		var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		if (string.IsNullOrWhiteSpace(query))
+		{
+			return dict;
+		}
+
+		var q = query.Trim();
+		if (q.StartsWith("?", StringComparison.Ordinal))
+		{
+			q = q[1..];
+		}
+		if (string.IsNullOrWhiteSpace(q))
+		{
+			return dict;
+		}
+
+		foreach (var part in q.Split('&', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			var kv = part.Split('=', 2);
+			if (kv.Length == 0 || string.IsNullOrWhiteSpace(kv[0]))
+			{
+				continue;
+			}
+
+			var k = Uri.UnescapeDataString(kv[0]);
+			if (dict.ContainsKey(k))
+			{
+				continue;
+			}
+
+			var v = kv.Length == 2 ? Uri.UnescapeDataString(kv[1]) : string.Empty;
+			dict[k] = v;
+		}
+
+		return dict;
 	}
 
 	private sealed record StreamSelection(int? AudioStreamIndex, int? SubtitleStreamIndex, string? SubtitleMethod);

--- a/src/Tindarr.Infrastructure/Playback/Providers/JellyfinPlaybackProvider.cs
+++ b/src/Tindarr.Infrastructure/Playback/Providers/JellyfinPlaybackProvider.cs
@@ -12,11 +12,22 @@ public sealed class JellyfinPlaybackProvider(
 	IServiceSettingsRepository settingsRepo,
 	ICastingSettingsRepository castingSettingsRepo,
 	HttpClient httpClient,
-	ILogger<JellyfinPlaybackProvider> logger) : IPlaybackProvider
+	ILogger<JellyfinPlaybackProvider> logger) : IDirectPlaybackProvider
 {
 	private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
 
 	public ServiceType ServiceType => ServiceType.Jellyfin;
+
+	public async Task<Uri?> TryBuildDirectMovieStreamUrlAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
+	{
+		var upstream = await BuildMovieStreamRequestAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+		if (!upstream.Headers.TryGetValue("X-Emby-Token", out var token) || string.IsNullOrWhiteSpace(token))
+		{
+			return null;
+		}
+
+		return AppendOrReplaceQuery(upstream.Uri, "api_key", token);
+	}
 
 	public async Task<UpstreamPlaybackRequest> BuildMovieStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
 	{
@@ -65,6 +76,55 @@ public sealed class JellyfinPlaybackProvider(
 			{
 				["X-Emby-Token"] = apiKey
 			});
+	}
+
+	private static Uri AppendOrReplaceQuery(Uri uri, string key, string value)
+	{
+		var builder = new UriBuilder(uri);
+		var all = ParseQuery(builder.Query);
+
+		all[key] = value;
+		builder.Query = string.Join("&", all.Select(kvp => $"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(kvp.Value)}"));
+		return builder.Uri;
+	}
+
+	private static Dictionary<string, string> ParseQuery(string? query)
+	{
+		var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		if (string.IsNullOrWhiteSpace(query))
+		{
+			return dict;
+		}
+
+		var q = query.Trim();
+		if (q.StartsWith("?", StringComparison.Ordinal))
+		{
+			q = q[1..];
+		}
+		if (string.IsNullOrWhiteSpace(q))
+		{
+			return dict;
+		}
+
+		foreach (var part in q.Split('&', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			var kv = part.Split('=', 2);
+			if (kv.Length == 0 || string.IsNullOrWhiteSpace(kv[0]))
+			{
+				continue;
+			}
+
+			var k = Uri.UnescapeDataString(kv[0]);
+			if (dict.ContainsKey(k))
+			{
+				continue;
+			}
+
+			var v = kv.Length == 2 ? Uri.UnescapeDataString(kv[1]) : string.Empty;
+			dict[k] = v;
+		}
+
+		return dict;
 	}
 
 	private sealed record StreamSelection(int? AudioStreamIndex, int? SubtitleStreamIndex, string? SubtitleMethod);

--- a/src/Tindarr.Infrastructure/Playback/Providers/PlexPlaybackProvider.cs
+++ b/src/Tindarr.Infrastructure/Playback/Providers/PlexPlaybackProvider.cs
@@ -17,7 +17,7 @@ public sealed class PlexPlaybackProvider(
 	IPlexLibraryCacheRepository plexCache,
 	HttpClient httpClient,
 	IOptions<PlexOptions> plexOptions,
-	ILogger<PlexPlaybackProvider> logger) : IPlaybackProvider
+	ILogger<PlexPlaybackProvider> logger) : IDirectPlaybackProvider
 {
 	private readonly PlexOptions _plexOptions = plexOptions.Value;
 
@@ -29,6 +29,34 @@ public sealed class PlexPlaybackProvider(
 	private const string ChromecastPlatformVersion = "1";
 
 	public ServiceType ServiceType => ServiceType.Plex;
+
+	public async Task<Uri?> TryBuildDirectMovieStreamUrlAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
+	{
+		var upstream = await BuildMovieStreamRequestAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+
+		// Cast devices can't send our custom headers, so push the relevant Plex identification headers into the URL.
+		var plexQuery = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var header in upstream.Headers)
+		{
+			if (!header.Key.StartsWith("X-Plex-", StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+			if (string.IsNullOrWhiteSpace(header.Value))
+			{
+				continue;
+			}
+
+			plexQuery[header.Key] = header.Value;
+		}
+
+		if (!plexQuery.TryGetValue("X-Plex-Token", out var token) || string.IsNullOrWhiteSpace(token))
+		{
+			return null;
+		}
+
+		return AppendOrReplaceQuery(upstream.Uri, plexQuery);
+	}
 
 	public async Task<UpstreamPlaybackRequest> BuildMovieStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
 	{
@@ -138,6 +166,72 @@ public sealed class PlexPlaybackProvider(
 		return new UpstreamPlaybackRequest(
 			Uri: upstreamUri,
 			Headers: headers);
+	}
+
+	private static Uri AppendOrReplaceQuery(Uri uri, IReadOnlyDictionary<string, string> queryToUpsert)
+	{
+		if (uri is null)
+		{
+			throw new ArgumentNullException(nameof(uri));
+		}
+		if (queryToUpsert is null)
+		{
+			throw new ArgumentNullException(nameof(queryToUpsert));
+		}
+
+		var builder = new UriBuilder(uri);
+		var all = ParseQuery(builder.Query);
+
+		foreach (var kvp in queryToUpsert)
+		{
+			if (string.IsNullOrWhiteSpace(kvp.Key) || string.IsNullOrWhiteSpace(kvp.Value))
+			{
+				continue;
+			}
+
+			all[kvp.Key] = kvp.Value;
+		}
+		builder.Query = string.Join("&", all.Select(kvp => $"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(kvp.Value)}"));
+		return builder.Uri;
+	}
+
+	private static Dictionary<string, string> ParseQuery(string? query)
+	{
+		var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		if (string.IsNullOrWhiteSpace(query))
+		{
+			return dict;
+		}
+
+		var q = query.Trim();
+		if (q.StartsWith("?", StringComparison.Ordinal))
+		{
+			q = q[1..];
+		}
+		if (string.IsNullOrWhiteSpace(q))
+		{
+			return dict;
+		}
+
+		foreach (var part in q.Split('&', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			var kv = part.Split('=', 2);
+			if (kv.Length == 0 || string.IsNullOrWhiteSpace(kv[0]))
+			{
+				continue;
+			}
+
+			var k = Uri.UnescapeDataString(kv[0]);
+			if (dict.ContainsKey(k))
+			{
+				continue;
+			}
+
+			var v = kv.Length == 2 ? Uri.UnescapeDataString(kv[1]) : string.Empty;
+			dict[k] = v;
+		}
+
+		return dict;
 	}
 
 	private sealed record PlexStreamSelection(int? AudioStreamId, int? SubtitleStreamId);

--- a/src/Tindarr.Infrastructure/PlexCache/Repositories/PlexDeckIndexRepository.cs
+++ b/src/Tindarr.Infrastructure/PlexCache/Repositories/PlexDeckIndexRepository.cs
@@ -144,7 +144,15 @@ public sealed class PlexDeckIndexRepository(PlexCacheDbContext db) : IPlexDeckIn
 		limit = Math.Clamp(limit, 1, 500);
 
 	var serverId = scope.ServerId;
-	var q = db.DeckEntries.AsNoTracking().Where(x => x.ServerId == serverId);
+	var libraryIds = db.LibraryItems
+		.AsNoTracking()
+		.Where(x => x.ServerId == serverId)
+		.Select(x => x.TmdbId);
+
+	var q = db.DeckEntries
+		.AsNoTracking()
+		.Where(x => x.ServerId == serverId)
+		.Where(x => libraryIds.Contains(x.TmdbId));
 
 		if (preferences.MinReleaseYear is { } minYear)
 		{

--- a/src/Tindarr.Infrastructure/PlexCache/Repositories/PlexLibraryCacheRepository.cs
+++ b/src/Tindarr.Infrastructure/PlexCache/Repositories/PlexLibraryCacheRepository.cs
@@ -9,6 +9,8 @@ namespace Tindarr.Infrastructure.PlexCache.Repositories;
 
 public sealed class PlexLibraryCacheRepository(PlexCacheDbContext db) : IPlexLibraryCacheRepository
 {
+	private const int SqliteParameterChunkSize = 400;
+
 	public async Task<IReadOnlyCollection<int>> GetTmdbIdsAsync(ServiceScope scope, CancellationToken cancellationToken)
 	{
 		if (scope.ServiceType != ServiceType.Plex)
@@ -156,6 +158,133 @@ public sealed class PlexLibraryCacheRepository(PlexCacheDbContext db) : IPlexLib
 		}
 	}
 
+	public async Task SyncItemsAsync(ServiceScope scope, IReadOnlyCollection<PlexLibraryItem> items, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken)
+	{
+		if (scope.ServiceType != ServiceType.Plex)
+		{
+			return;
+		}
+
+		var serverId = scope.ServerId;
+		var normalized = items
+			.Where(x => x.TmdbId > 0)
+			.GroupBy(x => x.TmdbId)
+			.Select(g =>
+			{
+				var best = g.FirstOrDefault(i => !string.IsNullOrWhiteSpace(i.RatingKey)) ?? g.First();
+				return new
+				{
+					TmdbId = g.Key,
+					RatingKey = Normalize(best.RatingKey),
+					Title = Normalize(best.Title)
+				};
+			})
+			.ToDictionary(x => x.TmdbId, x => (x.RatingKey, x.Title));
+
+		await using var tx = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+		try
+		{
+			if (normalized.Count == 0)
+			{
+				await db.LibraryItems
+					.Where(x => x.ServerId == serverId)
+					.ExecuteDeleteAsync(cancellationToken)
+					.ConfigureAwait(false);
+				await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+				return;
+			}
+
+			var existing = await db.LibraryItems
+				.AsNoTracking()
+				.Where(x => x.ServerId == serverId)
+				.Select(x => new { x.TmdbId, x.RatingKey, x.Title })
+				.ToListAsync(cancellationToken)
+				.ConfigureAwait(false);
+
+			var existingById = existing.ToDictionary(
+				x => x.TmdbId,
+				x => (RatingKey: Normalize(x.RatingKey), Title: Normalize(x.Title)));
+
+			var incomingIds = normalized.Keys.ToHashSet();
+			var existingIds = existingById.Keys.ToHashSet();
+
+			var toDelete = existingIds.Except(incomingIds).ToList();
+			for (var i = 0; i < toDelete.Count; i += SqliteParameterChunkSize)
+			{
+				var chunk = toDelete.Skip(i).Take(SqliteParameterChunkSize).ToList();
+				await db.LibraryItems
+					.Where(x => x.ServerId == serverId && chunk.Contains(x.TmdbId))
+					.ExecuteDeleteAsync(cancellationToken)
+					.ConfigureAwait(false);
+			}
+
+			var toAddIds = incomingIds.Except(existingIds).ToList();
+			if (toAddIds.Count > 0)
+			{
+				var addRows = new List<PlexLibraryCacheItemEntity>(toAddIds.Count);
+				foreach (var tmdbId in toAddIds)
+				{
+					var v = normalized[tmdbId];
+					addRows.Add(new PlexLibraryCacheItemEntity
+					{
+						ServerId = serverId,
+						TmdbId = tmdbId,
+						RatingKey = v.RatingKey,
+						Title = v.Title,
+						UpdatedAtUtc = syncedAtUtc
+					});
+				}
+
+				db.LibraryItems.AddRange(addRows);
+				try
+				{
+					await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+				}
+				catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+				{
+					// Ignore duplicates (unique constraint).
+				}
+			}
+
+			var toUpdate = incomingIds
+				.Intersect(existingIds)
+				.Where(id =>
+				{
+					var inc = normalized[id];
+					var cur = existingById[id];
+					return !string.Equals(inc.RatingKey, cur.RatingKey, StringComparison.Ordinal)
+						|| !string.Equals(inc.Title, cur.Title, StringComparison.Ordinal);
+				})
+				.ToList();
+
+			foreach (var tmdbId in toUpdate)
+			{
+				var inc = normalized[tmdbId];
+				await db.LibraryItems
+					.Where(x => x.ServerId == serverId && x.TmdbId == tmdbId)
+					.ExecuteUpdateAsync(setters => setters
+						.SetProperty(x => x.RatingKey, inc.RatingKey)
+						.SetProperty(x => x.Title, inc.Title)
+						.SetProperty(x => x.UpdatedAtUtc, syncedAtUtc),
+						cancellationToken)
+					.ConfigureAwait(false);
+			}
+
+			// Refresh UpdatedAtUtc for all remaining rows in one statement.
+			await db.LibraryItems
+				.Where(x => x.ServerId == serverId)
+				.ExecuteUpdateAsync(setters => setters.SetProperty(x => x.UpdatedAtUtc, syncedAtUtc), cancellationToken)
+				.ConfigureAwait(false);
+
+			await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+		}
+		catch
+		{
+			await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
+			throw;
+		}
+	}
+
 	public async Task AddTmdbIdsAsync(ServiceScope scope, IReadOnlyCollection<int> tmdbIds, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken)
 	{
 		if (scope.ServiceType != ServiceType.Plex)
@@ -224,5 +353,10 @@ public sealed class PlexLibraryCacheRepository(PlexCacheDbContext db) : IPlexLib
 		return exception.InnerException is SqliteException sqliteException
 			&& (sqliteException.SqliteExtendedErrorCode == 1555
 				|| sqliteException.SqliteExtendedErrorCode == 2067);
+	}
+
+	private static string? Normalize(string? value)
+	{
+		return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 	}
 }

--- a/tests/Tindarr.UnitTests/Infrastructure/Playback/PlexPlaybackProviderStreamSelectionTests.cs
+++ b/tests/Tindarr.UnitTests/Infrastructure/Playback/PlexPlaybackProviderStreamSelectionTests.cs
@@ -82,6 +82,58 @@ public sealed class PlexPlaybackProviderStreamSelectionTests
 	}
 
 	[Fact]
+	public async Task TryBuildDirectMovieStreamUrlAsync_AppendsPlexTokenQuery()
+	{
+		var metadataXml = """
+		<MediaContainer size="1">
+		  <Video ratingKey="999" type="movie">
+		    <Media id="1" selected="1">
+		      <Part id="10" selected="1" />
+		    </Media>
+		  </Video>
+		</MediaContainer>
+		""";
+
+		var httpClient = new HttpClient(new PlexMetadataHandler(metadataXml));
+
+		var settingsRepo = new FakeServiceSettingsRepository(
+			server: CreateServiceSettingsRecord(
+				serviceType: ServiceType.Plex,
+				serverId: "server-1",
+				plexServerUri: "http://127.0.0.1:32400",
+				plexServerAccessToken: "server-token",
+				plexClientIdentifier: "client-1"),
+			account: CreateServiceSettingsRecord(
+				serviceType: ServiceType.Plex,
+				serverId: PlexConstants.AccountServerId,
+				plexServerUri: "http://127.0.0.1:32400",
+				plexAuthToken: "account-token",
+				plexClientIdentifier: "client-1"));
+
+		var castingSettingsRepo = new FakeCastingSettingsRepository(null);
+		var plexCache = new FakePlexLibraryCacheRepository(ratingKey: "999");
+		var options = Options.Create(new PlexOptions());
+
+		var provider = new PlexPlaybackProvider(
+			settingsRepo,
+			castingSettingsRepo,
+			plexCache,
+			httpClient,
+			options,
+			NullLogger<PlexPlaybackProvider>.Instance);
+
+		var uri = await provider.TryBuildDirectMovieStreamUrlAsync(new ServiceScope(ServiceType.Plex, "server-1"), 123, CancellationToken.None);
+		Assert.NotNull(uri);
+		var s = uri!.ToString();
+		Assert.Contains("X-Plex-Token=server-token", s, StringComparison.Ordinal);
+		Assert.Contains("X-Plex-Platform=Chromecast", s, StringComparison.Ordinal);
+		Assert.Contains("X-Plex-Device=Chromecast", s, StringComparison.Ordinal);
+		Assert.Contains("X-Plex-Model=Chromecast", s, StringComparison.Ordinal);
+		Assert.Contains("X-Plex-Platform-Version=1", s, StringComparison.Ordinal);
+		Assert.Contains("X-Plex-Client-Identifier=client-1", s, StringComparison.Ordinal);
+	}
+
+	[Fact]
 	public async Task BuildMovieStreamRequestAsync_RespectsAudioTrackKindCommentary()
 	{
 		var metadataXml = """
@@ -229,6 +281,9 @@ public sealed class PlexPlaybackProviderStreamSelectionTests
 			throw new NotSupportedException();
 
 		public Task ReplaceItemsAsync(ServiceScope scope, IReadOnlyCollection<PlexLibraryItem> items, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken) =>
+			throw new NotSupportedException();
+
+		public Task SyncItemsAsync(ServiceScope scope, IReadOnlyCollection<PlexLibraryItem> items, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken) =>
 			throw new NotSupportedException();
 
 		public Task AddTmdbIdsAsync(ServiceScope scope, IReadOnlyCollection<int> tmdbIds, DateTimeOffset syncedAtUtc, CancellationToken cancellationToken) =>

--- a/tests/Tindarr.UnitTests/Interactions/SwipeDeckServiceTests.cs
+++ b/tests/Tindarr.UnitTests/Interactions/SwipeDeckServiceTests.cs
@@ -43,6 +43,8 @@ public sealed class SwipeDeckServiceTests
 
 		public Task<Interaction?> UndoLastAsync(string userId, ServiceScope scope, CancellationToken cancellationToken) => throw new NotSupportedException();
 
+		public Task ClearHistoryAsync(string userId, ServiceScope scope, CancellationToken cancellationToken) => throw new NotSupportedException();
+
 		public Task<IReadOnlyCollection<int>> GetInteractedTmdbIdsAsync(string userId, ServiceScope scope, CancellationToken cancellationToken)
 		{
 			return Task.FromResult(interacted);

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -62,7 +62,9 @@ import type {
   RoomMatchesResponse,
   RoomStateResponse,
   CastDeviceDto,
-  CastMovieRequest
+  CastMovieRequest,
+  CastMediaUrlDto,
+  GetMovieCastUrlRequest
 } from "./contracts";
 import { ApiError, apiRequest } from "./http";
 import { getCachedJson, setCachedJson } from "./localCache";
@@ -117,6 +119,14 @@ export async function undoSwipe(
     path: "/api/v1/interactions/undo",
     method: "POST",
     query: { serviceType: scope.serviceType, serverId: scope.serverId }
+  });
+}
+
+export async function clearInteractionHistory(serviceType: string, serverId: string): Promise<void> {
+  return apiRequest<void>({
+    path: "/api/v1/interactions",
+    method: "DELETE",
+    query: { serviceType: serviceType.trim().toLowerCase(), serverId: serverId.trim() || "default" }
   });
 }
 
@@ -310,9 +320,24 @@ export async function castRoomQr(roomId: string, deviceId: string): Promise<void
   });
 }
 
+export async function getRoomQrCastUrl(roomId: string): Promise<CastMediaUrlDto> {
+  return apiRequest<CastMediaUrlDto>({
+    path: `/api/v1/casting/rooms/${encodeURIComponent(roomId)}/qr/cast-url`,
+    method: "GET"
+  });
+}
+
 export async function castMovie(request: CastMovieRequest): Promise<void> {
   await apiRequest<void>({
     path: "/api/v1/casting/movie",
+    method: "POST",
+    body: request
+  });
+}
+
+export async function getMovieCastUrl(request: GetMovieCastUrlRequest): Promise<CastMediaUrlDto> {
+  return apiRequest<CastMediaUrlDto>({
+    path: "/api/v1/casting/movie/cast-url",
     method: "POST",
     body: request
   });

--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -243,6 +243,20 @@ export type CastMovieRequest = {
   title?: string | null;
 };
 
+export type CastMediaUrlDto = {
+  url: string;
+  contentType: string;
+  title: string;
+  subTitle: string | null;
+};
+
+export type GetMovieCastUrlRequest = {
+  serviceType: string;
+  serverId: string;
+  tmdbId: number;
+  title?: string | null;
+};
+
 export type MovieDetailsDto = {
   tmdbId: number;
   title: string;

--- a/ui/src/casting/googleCast.ts
+++ b/ui/src/casting/googleCast.ts
@@ -1,0 +1,141 @@
+type CastDeviceInfo = {
+  friendlyName: string;
+};
+
+const CAST_SDK_URL = "https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1";
+const DEFAULT_MEDIA_RECEIVER_APP_ID = "CC1AD845";
+
+function isIos(): boolean {
+  const ua = navigator.userAgent;
+  return /iPad|iPhone|iPod/i.test(ua);
+}
+
+function isSafari(): boolean {
+  const ua = navigator.userAgent;
+  return /Safari/i.test(ua) && !/Chrome|Chromium|Edg|OPR/i.test(ua);
+}
+
+export function shouldUseGoogleCastSdk(): boolean {
+  // Google Cast Web Sender SDK isn't supported on iOS/Safari.
+  if (typeof window === "undefined") return false;
+  if (isIos()) return false;
+  if (isSafari()) return false;
+  return true;
+}
+
+function isCastFrameworkReady(): boolean {
+  return Boolean((window as any).cast?.framework?.CastContext);
+}
+
+function ensureCastScriptTag(): HTMLScriptElement {
+  const existing = document.querySelector(`script[src^="${CAST_SDK_URL}"]`) as HTMLScriptElement | null;
+  if (existing) return existing;
+
+  const script = document.createElement("script");
+  script.src = CAST_SDK_URL;
+  script.async = true;
+  document.head.appendChild(script);
+  return script;
+}
+
+export async function ensureGoogleCastSdkLoaded(): Promise<boolean> {
+  if (!shouldUseGoogleCastSdk()) return false;
+  if (isCastFrameworkReady()) return true;
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+
+    const timeout = window.setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error("Cast SDK load timed out"));
+    }, 8000);
+
+    (window as any).__onGCastApiAvailable = (isAvailable: boolean) => {
+      if (settled) return;
+      window.clearTimeout(timeout);
+      settled = true;
+      if (!isAvailable) {
+        reject(new Error("Cast API not available"));
+        return;
+      }
+      resolve();
+    };
+
+    const script = ensureCastScriptTag();
+    script.addEventListener(
+      "error",
+      () => {
+        if (settled) return;
+        window.clearTimeout(timeout);
+        settled = true;
+        reject(new Error("Cast SDK failed to load"));
+      },
+      { once: true }
+    );
+  });
+
+  return isCastFrameworkReady();
+}
+
+export function initGoogleCastContext(): void {
+  if (!isCastFrameworkReady()) {
+    throw new Error("Cast framework not ready");
+  }
+
+  const castAny = (window as any).cast as any;
+  const chromeAny = (window as any).chrome as any;
+  const receiverId = chromeAny?.cast?.media?.DEFAULT_MEDIA_RECEIVER_APP_ID ?? DEFAULT_MEDIA_RECEIVER_APP_ID;
+
+  const context = castAny.framework.CastContext.getInstance();
+  context.setOptions({
+    receiverApplicationId: receiverId,
+    autoJoinPolicy: chromeAny.cast.AutoJoinPolicy.ORIGIN_SCOPED,
+  });
+}
+
+export async function requestCastSession(): Promise<CastDeviceInfo> {
+  const castAny = (window as any).cast as any;
+  const context = castAny.framework.CastContext.getInstance();
+  await context.requestSession();
+  const session = context.getCurrentSession();
+  const device = session?.getCastDevice?.();
+  const name = (device?.friendlyName ?? "Cast device") as string;
+  return { friendlyName: name };
+}
+
+export function getCurrentCastDevice(): CastDeviceInfo | null {
+  if (!isCastFrameworkReady()) return null;
+  const castAny = (window as any).cast as any;
+  const context = castAny.framework.CastContext.getInstance();
+  const session = context.getCurrentSession();
+  const device = session?.getCastDevice?.();
+  const name = (device?.friendlyName ?? "") as string;
+  return name ? { friendlyName: name } : null;
+}
+
+export async function loadMediaToCastSession(args: { url: string; contentType: string; title: string; subTitle?: string | null }): Promise<void> {
+  if (!isCastFrameworkReady()) {
+    throw new Error("Cast framework not ready");
+  }
+
+  const castAny = (window as any).cast as any;
+  const chromeAny = (window as any).chrome as any;
+  const context = castAny.framework.CastContext.getInstance();
+
+  const session = context.getCurrentSession();
+  if (!session) {
+    throw new Error("No cast session");
+  }
+
+  const mediaInfo = new chromeAny.cast.media.MediaInfo(args.url, args.contentType);
+  mediaInfo.metadata = new chromeAny.cast.media.GenericMediaMetadata();
+  mediaInfo.metadata.title = args.title;
+  if (args.subTitle) {
+    mediaInfo.metadata.subtitle = args.subTitle;
+  }
+
+  const request = new chromeAny.cast.media.LoadRequest(mediaInfo);
+  request.autoplay = true;
+  await session.loadMedia(request);
+}

--- a/ui/src/components/MovieDetailsModal.tsx
+++ b/ui/src/components/MovieDetailsModal.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { ApiError } from "../api/http";
-import { castMovie, fetchMovieDetails, listCastDevices } from "../api/client";
+import { castMovie, fetchMovieDetails, getMovieCastUrl, listCastDevices } from "../api/client";
 import type { CastDeviceDto, MovieDetailsDto } from "../api/contracts";
 import { getServiceScope, SERVICE_SCOPE_UPDATED_EVENT, type ServiceScope } from "../serviceScope";
+import { ensureGoogleCastSdkLoaded, getCurrentCastDevice, initGoogleCastContext, loadMediaToCastSession, requestCastSession, shouldUseGoogleCastSdk } from "../casting/googleCast";
 
 type MovieDetailsModalProps = {
   tmdbId: number;
@@ -21,6 +22,7 @@ export default function MovieDetailsModal({ tmdbId, onClose }: MovieDetailsModal
   const [castLoading, setCastLoading] = useState(false);
   const [casting, setCasting] = useState(false);
   const [castMessage, setCastMessage] = useState<string | null>(null);
+  const [castUiMode, setCastUiMode] = useState<"sdk" | "fallback">(() => (shouldUseGoogleCastSdk() ? "sdk" : "fallback"));
 
   const posterUrl = details?.posterUrl ?? null;
 
@@ -72,6 +74,7 @@ export default function MovieDetailsModal({ tmdbId, onClose }: MovieDetailsModal
   }, [currentScope.serviceType]);
 
   async function onLoadCastDevices() {
+    if (castUiMode === "sdk") return;
     setCastLoading(true);
     setCastMessage(null);
     setError(null);
@@ -96,12 +99,45 @@ export default function MovieDetailsModal({ tmdbId, onClose }: MovieDetailsModal
   }
 
   async function onCastMovie() {
-    if (!castDeviceId) return;
+    if (castUiMode === "fallback" && !castDeviceId) return;
 
     setCasting(true);
     setCastMessage(null);
     setError(null);
     try {
+      if (castUiMode === "sdk") {
+        const ok = await ensureGoogleCastSdkLoaded();
+        if (!ok) {
+          setCastUiMode("fallback");
+          setCastMessage("Google Cast isn’t available in this browser. Use the device picker below.");
+          return;
+        }
+
+        initGoogleCastContext();
+
+        const current = getCurrentCastDevice();
+        if (!current) {
+          await requestCastSession();
+        }
+
+        const media = await getMovieCastUrl({
+          serviceType: currentScope.serviceType,
+          serverId: currentScope.serverId,
+          tmdbId,
+          title: details?.title ?? null,
+        });
+
+        await loadMediaToCastSession({
+          url: media.url,
+          contentType: media.contentType,
+          title: media.title,
+          subTitle: media.subTitle,
+        });
+
+        setCastMessage("Casting…");
+        return;
+      }
+
       await castMovie({
         deviceId: castDeviceId,
         serviceType: currentScope.serviceType,
@@ -114,7 +150,9 @@ export default function MovieDetailsModal({ tmdbId, onClose }: MovieDetailsModal
       if (e instanceof ApiError) {
         setError(e.message);
       } else {
-        setError("Failed to cast movie.");
+        setError(
+          "Failed to cast movie. If you are running on localhost, configure a LAN join address (Admin Console) and ensure the API is reachable from your Chromecast (bind to 0.0.0.0 / LAN IP).",
+        );
       }
     } finally {
       setCasting(false);
@@ -183,26 +221,34 @@ export default function MovieDetailsModal({ tmdbId, onClose }: MovieDetailsModal
                     <div style={{ marginTop: "1rem" }}>
                       <div className="field__label">Cast</div>
                       <div style={{ marginTop: "0.25rem", display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "center" }}>
-                        <button type="button" className="button button--ghost" onClick={onLoadCastDevices} disabled={castLoading || casting}>
-                          {castLoading ? "Finding devices…" : "Find devices"}
-                        </button>
-                        <select
-                          className="field__input"
-                          style={{ minWidth: 220 }}
-                          value={castDeviceId}
-                          onChange={(e) => setCastDeviceId(e.target.value)}
-                          disabled={castLoading || casting || castDevices.length === 0}
-                        >
-                          {castDevices.length === 0 ? <option value="">No devices</option> : null}
-                          {castDevices.map((d) => (
-                            <option key={d.id} value={d.id}>
-                              {d.name}
-                            </option>
-                          ))}
-                        </select>
-                        <button type="button" className="button" onClick={onCastMovie} disabled={casting || castLoading || !castDeviceId}>
-                          {casting ? "Casting…" : "Cast"}
-                        </button>
+                        {castUiMode === "sdk" ? (
+                          <button type="button" className="button" onClick={onCastMovie} disabled={casting}>
+                            {casting ? "Casting…" : "Cast"}
+                          </button>
+                        ) : (
+                          <>
+                            <button type="button" className="button button--ghost" onClick={onLoadCastDevices} disabled={castLoading || casting}>
+                              {castLoading ? "Finding devices…" : "Find devices"}
+                            </button>
+                            <select
+                              className="field__input"
+                              style={{ minWidth: 220 }}
+                              value={castDeviceId}
+                              onChange={(e) => setCastDeviceId(e.target.value)}
+                              disabled={castLoading || casting || castDevices.length === 0}
+                            >
+                              {castDevices.length === 0 ? <option value="">No devices</option> : null}
+                              {castDevices.map((d) => (
+                                <option key={d.id} value={d.id}>
+                                  {d.name}
+                                </option>
+                              ))}
+                            </select>
+                            <button type="button" className="button" onClick={onCastMovie} disabled={casting || castLoading || !castDeviceId}>
+                              {casting ? "Casting…" : "Cast"}
+                            </button>
+                          </>
+                        )}
                       </div>
                       {castMessage ? <div style={{ marginTop: "0.5rem" }}>{castMessage}</div> : null}
                     </div>

--- a/ui/src/pages/PreferencesPage.tsx
+++ b/ui/src/pages/PreferencesPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate, type Location } from "react-router-dom";
 import { ApiError } from "../api/http";
-import { getPreferences, updatePreferences } from "../api/client";
-import type { UserPreferencesDto } from "../api/contracts";
+import { clearInteractionHistory, fetchConfiguredScopes, getPreferences, updatePreferences } from "../api/client";
+import type { ServiceScopeOptionDto, UserPreferencesDto } from "../api/contracts";
 import { TMDB_LANGUAGES, TMDB_MOVIE_GENRES, TMDB_REGIONS, TMDB_SORT_BY } from "../tmdb/knownValues";
 
 type FormState = {
@@ -131,6 +131,12 @@ export default function PreferencesPage() {
   const [prefs, setPrefs] = useState<UserPreferencesDto | null>(null);
   const [form, setForm] = useState<FormState | null>(null);
 
+  const [scopesLoading, setScopesLoading] = useState(false);
+  const [scopes, setScopes] = useState<ServiceScopeOptionDto[] | null>(null);
+  const [clearBusyKey, setClearBusyKey] = useState<string | null>(null);
+  const [clearError, setClearError] = useState<string | null>(null);
+  const [clearMessage, setClearMessage] = useState<string | null>(null);
+
   const updatedAt = useMemo(() => (prefs?.updatedAtUtc ? new Date(prefs.updatedAtUtc) : null), [prefs?.updatedAtUtc]);
 
   function handleClose() {
@@ -168,6 +174,48 @@ export default function PreferencesPage() {
       }
     })();
   }, []);
+
+  async function loadScopes() {
+    try {
+      setScopesLoading(true);
+      setClearError(null);
+      const next = await fetchConfiguredScopes();
+      setScopes(next);
+    } catch (err) {
+      setClearError(err instanceof Error ? err.message : "Failed to load scopes.");
+    } finally {
+      setScopesLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadScopes();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function handleClearHistory(scope: ServiceScopeOptionDto) {
+    const key = `${scope.serviceType}:${scope.serverId}`;
+    try {
+      setClearBusyKey(key);
+      setClearError(null);
+      setClearMessage(null);
+      await clearInteractionHistory(scope.serviceType, scope.serverId);
+      setClearMessage(`Cleared interaction history for ${scope.displayName}.`);
+
+      // Let the background swipedeck refresh immediately after a successful clear.
+      window.dispatchEvent(new Event("tindarr:interactionHistoryCleared"));
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setClearError(err.message);
+      } else if (err instanceof Error) {
+        setClearError(err.message);
+      } else {
+        setClearError("Failed to clear interaction history.");
+      }
+    } finally {
+      setClearBusyKey(null);
+    }
+  }
 
   async function handleSave() {
     if (!form) return;
@@ -416,6 +464,45 @@ export default function PreferencesPage() {
                     {saving ? "Saving…" : "Save preferences"}
                   </button>
                 </div>
+
+        <div className="field">
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "1rem" }}>
+            <span className="field__label">Interaction history</span>
+            <button type="button" className="button button--ghost" onClick={() => void loadScopes()} disabled={scopesLoading}>
+              {scopesLoading ? "Refreshing…" : "Refresh scopes"}
+            </button>
+          </div>
+
+          {clearError ? <div className="deck__state deck__state--error">{clearError}</div> : null}
+          {clearMessage ? <div className="deck__state">{clearMessage}</div> : null}
+          {scopesLoading && !scopes ? <div className="deck__state">Loading scopes…</div> : null}
+
+          {!scopesLoading && scopes && scopes.length === 0 ? (
+            <div className="deck__state">No configured scopes found.</div>
+          ) : null}
+
+          {scopes && scopes.length > 0 ? (
+            <div style={{ display: "grid", gap: "0.5rem" }}>
+              {scopes.map((s) => {
+                const key = `${s.serviceType}:${s.serverId}`;
+                const busy = clearBusyKey === key;
+                return (
+                  <div key={key} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "1rem" }}>
+                    <div style={{ fontWeight: 600 }}>{s.displayName}</div>
+                    <button
+                      type="button"
+                      className="button button--nope"
+                      onClick={() => void handleClearHistory(s)}
+                      disabled={busy}
+                    >
+                      {busy ? "Clearing…" : "Clear history"}
+                    </button>
+                  </div>
+              );
+            })}
+            </div>
+          ) : null}
+        </div>
               </div>
             ) : (
               <div className="deck__state deck__state--error">Preferences failed to load.</div>

--- a/ui/src/pages/RoomPage.tsx
+++ b/ui/src/pages/RoomPage.tsx
@@ -4,8 +4,9 @@ import QRCode from "qrcode";
 import SwipeCardComponent from "../components/SwipeCard";
 import MovieDetailsModal from "../components/MovieDetailsModal";
 import { getServiceScope, SERVICE_SCOPE_UPDATED_EVENT, type ServiceScope } from "../serviceScope";
-import { castRoomQr, closeRoom, createRoom, fetchRoomSwipeDeck, fetchSwipeDeck, getRoom, getRoomJoinUrl, getRoomMatches, joinRoom, listCastDevices, sendRoomSwipe } from "../api/client";
+import { castRoomQr, closeRoom, createRoom, fetchRoomSwipeDeck, fetchSwipeDeck, getRoom, getRoomJoinUrl, getRoomMatches, getRoomQrCastUrl, joinRoom, listCastDevices, sendRoomSwipe } from "../api/client";
 import type { CastDeviceDto, RoomJoinUrlResponse, RoomMatchesResponse, RoomStateResponse } from "../api/contracts";
+import { ensureGoogleCastSdkLoaded, getCurrentCastDevice, initGoogleCastContext, loadMediaToCastSession, requestCastSession, shouldUseGoogleCastSdk } from "../casting/googleCast";
 import { ApiError } from "../api/http";
 import { useAuth } from "../auth/AuthContext";
 import type { SwipeAction, SwipeCard } from "../types";
@@ -33,6 +34,7 @@ export default function RoomPage() {
   const [castLoading, setCastLoading] = useState(false);
   const [casting, setCasting] = useState(false);
   const [castMessage, setCastMessage] = useState<string | null>(null);
+  const [castUiMode, setCastUiMode] = useState<"sdk" | "fallback">(() => (shouldUseGoogleCastSdk() ? "sdk" : "fallback"));
 
   const [cards, setCards] = useState<SwipeCard[]>([]);
   const [deckLoading, setDeckLoading] = useState(false);
@@ -288,6 +290,7 @@ export default function RoomPage() {
   }
 
   async function onLoadCastDevices() {
+    if (castUiMode === "sdk") return;
     setCastLoading(true);
     setCastMessage(null);
     setError(null);
@@ -313,19 +316,46 @@ export default function RoomPage() {
 
   async function onCastQr() {
     if (!roomId) return;
-    if (!castDeviceId) return;
+    if (castUiMode === "fallback" && !castDeviceId) return;
 
     setCasting(true);
     setCastMessage(null);
     setError(null);
     try {
+      if (castUiMode === "sdk") {
+        const ok = await ensureGoogleCastSdkLoaded();
+        if (!ok) {
+          setCastUiMode("fallback");
+          setCastMessage("Google Cast isn’t available in this browser. Use the device picker below.");
+          return;
+        }
+
+        initGoogleCastContext();
+
+        const current = getCurrentCastDevice();
+        if (!current) {
+          await requestCastSession();
+        }
+
+        const media = await getRoomQrCastUrl(roomId);
+        await loadMediaToCastSession({
+          url: media.url,
+          contentType: media.contentType,
+          title: media.title,
+          subTitle: media.subTitle,
+        });
+
+        setCastMessage("Casting QR…");
+        return;
+      }
+
       await castRoomQr(roomId, castDeviceId);
       setCastMessage("Casting QR…");
     } catch (e) {
       if (e instanceof ApiError) {
         setError(e.message);
       } else {
-        setError("Failed to cast QR.");
+        setError("Failed to cast QR. If you are running on localhost, configure a LAN join address (Admin Console) and ensure the API is reachable from your Chromecast (bind to 0.0.0.0 / LAN IP)." );
       }
     } finally {
       setCasting(false);
@@ -555,26 +585,34 @@ export default function RoomPage() {
           <div style={{ marginTop: "0.75rem" }}>
             <div className="field__label">Cast QR</div>
             <div style={{ marginTop: "0.25rem", display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "center" }}>
-              <button type="button" className="button button--ghost" onClick={onLoadCastDevices} disabled={castLoading || casting}>
-                {castLoading ? "Finding devices…" : "Find devices"}
-              </button>
-              <select
-                className="field__input"
-                style={{ minWidth: 220 }}
-                value={castDeviceId}
-                onChange={(e) => setCastDeviceId(e.target.value)}
-                disabled={castLoading || casting || castDevices.length === 0}
-              >
-                {castDevices.length === 0 ? <option value="">No devices</option> : null}
-                {castDevices.map((d) => (
-                  <option key={d.id} value={d.id}>
-                    {d.name}
-                  </option>
-                ))}
-              </select>
-              <button type="button" className="button" onClick={onCastQr} disabled={casting || castLoading || !castDeviceId}>
-                {casting ? "Casting…" : "Cast QR"}
-              </button>
+              {castUiMode === "sdk" ? (
+                <button type="button" className="button" onClick={onCastQr} disabled={casting}>
+                  {casting ? "Casting…" : "Cast QR"}
+                </button>
+              ) : (
+                <>
+                  <button type="button" className="button button--ghost" onClick={onLoadCastDevices} disabled={castLoading || casting}>
+                    {castLoading ? "Finding devices…" : "Find devices"}
+                  </button>
+                  <select
+                    className="field__input"
+                    style={{ minWidth: 220 }}
+                    value={castDeviceId}
+                    onChange={(e) => setCastDeviceId(e.target.value)}
+                    disabled={castLoading || casting || castDevices.length === 0}
+                  >
+                    {castDevices.length === 0 ? <option value="">No devices</option> : null}
+                    {castDevices.map((d) => (
+                      <option key={d.id} value={d.id}>
+                        {d.name}
+                      </option>
+                    ))}
+                  </select>
+                  <button type="button" className="button" onClick={onCastQr} disabled={casting || castLoading || !castDeviceId}>
+                    {casting ? "Casting…" : "Cast QR"}
+                  </button>
+                </>
+              )}
             </div>
             {castMessage ? <div style={{ marginTop: "0.5rem" }}>{castMessage}</div> : null}
           </div>

--- a/ui/src/pages/SwipeDeckPage.tsx
+++ b/ui/src/pages/SwipeDeckPage.tsx
@@ -294,12 +294,16 @@ export default function SwipeDeckPage() {
 
   // Live-reload swipedeck when preferences are saved (Preferences modal dispatches this).
   useEffect(() => {
-    function handlePreferencesUpdated() {
+    function handleDeckInputsUpdated() {
       void loadDeck();
     }
 
-    window.addEventListener("tindarr:preferencesUpdated", handlePreferencesUpdated);
-    return () => window.removeEventListener("tindarr:preferencesUpdated", handlePreferencesUpdated);
+    window.addEventListener("tindarr:preferencesUpdated", handleDeckInputsUpdated);
+    window.addEventListener("tindarr:interactionHistoryCleared", handleDeckInputsUpdated);
+    return () => {
+      window.removeEventListener("tindarr:preferencesUpdated", handleDeckInputsUpdated);
+      window.removeEventListener("tindarr:interactionHistoryCleared", handleDeckInputsUpdated);
+    };
   }, [loadDeck]);
 
   // Live-reload when service scope changes (e.g., tmdb -> plex/server).


### PR DESCRIPTION
﻿Summary:
- Add Google Cast SDK support in the UI
- Provide built-in casting fallback for unsupported devices
- Add cast media URL support and related API/contract changes
- Improve playback provider stream selection + associated tests

Notes:
- Source branch: dev
- Target branch: main

## Summary by Sourcery

Add Google Cast SDK-based casting to the web UI with a fallback device picker, introduce castable media URL endpoints and direct-play support from media servers, and enhance interaction handling and Plex library syncing to improve swipe deck relevance.

New Features:
- Expose API endpoints and DTOs for generating castable media URLs for movies and room QR codes, including HTTP headers that surface those URLs to clients.
- Integrate Google Cast Web Sender SDK in the UI for one-click casting of movies and room QR codes, with automatic fallback to the existing device-based casting flow when the SDK or browser is unsupported.
- Add a user-facing control in Preferences to clear interaction history per configured service scope and trigger live swipe deck refreshes.

Bug Fixes:
- Ensure swipe deck results for Plex only include titles that still exist in the Plex library cache, avoiding cards for removed items.
- Harden Radarr pending-add retrieval against additional provider translation exceptions when querying by DateTimeOffset.

Enhancements:
- Add an optional direct-play capability to playback providers and implement it for Plex, Emby, and Jellyfin so cast devices can prefer direct media-server URLs when possible before falling back to the playback gateway.
- Introduce an incremental Plex library cache sync that adds, updates, and deletes items efficiently while normalizing fields and batching deletes for SQLite.
- Improve casting error messages in the UI to guide users running on localhost to configure LAN access and base URLs.
- Make dev startup more reliable by adding a short delay between starting the API and worker processes.

Documentation:
- Update playback gateway architecture docs to describe the new casting flow that prefers direct media-server URLs with a gateway fallback.

Tests:
- Extend Plex playback provider tests to cover direct-play URL generation and header-to-query propagation, and adapt interaction tests to the new history clearing capability.