### PR TITLE
Cast functionality expansion

### DIFF
--- a/build/scripts/dev.ps1
+++ b/build/scripts/dev.ps1
@@ -216,6 +216,7 @@ try {
 	}
 
 	if (-not $ApiOnly) {
+		Start-Sleep -Seconds 5
 		$uiProc = Start-Ui -repoRoot $repoRoot -apiUrl $proxyTarget -uiPort $UiPort
 	}
 

--- a/src/Tindarr.Api/Controllers/AdminController.cs
+++ b/src/Tindarr.Api/Controllers/AdminController.cs
@@ -1,5 +1,8 @@
+using System.Text.Json;
+using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Tindarr.Api.Auth;
 using Tindarr.Application.Interfaces.Interactions;
@@ -32,6 +35,97 @@ public sealed class AdminController(
 	{
 		var diagnostics = castingSessionStore.GetDiagnostics();
 		return Ok(diagnostics);
+	}
+
+	[HttpGet("casting/diagnostics/stream")]
+	public async Task GetCastingDiagnosticsStream(CancellationToken cancellationToken)
+	{
+		Response.ContentType = "text/event-stream";
+		Response.Headers.CacheControl = "no-cache";
+		Response.Headers.Connection = "keep-alive";
+		Response.Headers["X-Accel-Buffering"] = "no";
+
+		var jsonOptions = HttpContext.RequestServices
+			.GetRequiredService<IOptions<JsonOptions>>()
+			.Value
+			.JsonSerializerOptions;
+
+		var channel = Channel.CreateUnbounded<int>(new UnboundedChannelOptions
+		{
+			SingleReader = true,
+			SingleWriter = false
+		});
+
+		void SignalSnapshot() => channel.Writer.TryWrite(0);
+
+		EventHandler<Tindarr.Infrastructure.Casting.CastingEventArgs> onChanged = (_, __) => SignalSnapshot();
+		castingSessionStore.SessionStarted += onChanged;
+		castingSessionStore.SessionEnded += onChanged;
+		castingSessionStore.SessionError += onChanged;
+
+		static async Task WriteComment(HttpResponse response, string text, CancellationToken ct)
+		{
+			await response.WriteAsync($": {text}\n\n", ct);
+			await response.Body.FlushAsync(ct);
+		}
+
+		static async Task WriteEvent(HttpResponse response, string eventName, string json, CancellationToken ct)
+		{
+			await response.WriteAsync($"event: {eventName}\n", ct);
+			await response.WriteAsync($"data: {json}\n\n", ct);
+			await response.Body.FlushAsync(ct);
+		}
+
+		async Task WriteSnapshot(CancellationToken ct)
+		{
+			var snapshot = castingSessionStore.GetDiagnostics();
+			var json = JsonSerializer.Serialize(snapshot, jsonOptions);
+			await WriteEvent(Response, eventName: "diagnostics", json, ct);
+		}
+
+		var keepAliveInterval = TimeSpan.FromSeconds(15);
+		var periodicSnapshotInterval = TimeSpan.FromSeconds(30);
+		var lastSnapshotAt = DateTimeOffset.MinValue;
+
+		try
+		{
+			await WriteSnapshot(cancellationToken);
+			lastSnapshotAt = DateTimeOffset.UtcNow;
+
+			while (!cancellationToken.IsCancellationRequested)
+			{
+				var delayTask = Task.Delay(keepAliveInterval, cancellationToken);
+				var readTask = channel.Reader.ReadAsync(cancellationToken).AsTask();
+				var completed = await Task.WhenAny(delayTask, readTask).ConfigureAwait(false);
+
+				if (completed == delayTask)
+				{
+					await WriteComment(Response, "keepalive", cancellationToken);
+					if (DateTimeOffset.UtcNow - lastSnapshotAt >= periodicSnapshotInterval)
+					{
+						await WriteSnapshot(cancellationToken);
+						lastSnapshotAt = DateTimeOffset.UtcNow;
+					}
+					continue;
+				}
+
+				// Drain any queued signals so we coalesce multiple events into one snapshot.
+				while (channel.Reader.TryRead(out _)) { }
+
+				await WriteSnapshot(cancellationToken);
+				lastSnapshotAt = DateTimeOffset.UtcNow;
+			}
+		}
+		catch (OperationCanceledException)
+		{
+			// client disconnected
+		}
+		finally
+		{
+			castingSessionStore.SessionStarted -= onChanged;
+			castingSessionStore.SessionEnded -= onChanged;
+			castingSessionStore.SessionError -= onChanged;
+		}
 	}
 
 

--- a/src/Tindarr.Api/Controllers/CastingController.cs
+++ b/src/Tindarr.Api/Controllers/CastingController.cs
@@ -34,6 +34,19 @@ public sealed class CastingController(
 	ILogger<CastingController> logger,
 	Tindarr.Infrastructure.Casting.CastingSessionStore castingSessionStore) : ControllerBase
 {
+	[HttpPost("sessions/{sessionId}/end")]
+	[Authorize]
+	public IActionResult EndCastingSession([FromRoute] string sessionId)
+	{
+		if (string.IsNullOrWhiteSpace(sessionId))
+		{
+			return BadRequest("sessionId is required.");
+		}
+
+		castingSessionStore.EndSession(sessionId.Trim());
+		return Ok();
+	}
+
 	[HttpGet("devices")]
 	[Authorize]
 	public async Task<ActionResult<IReadOnlyList<CastDeviceDto>>> ListDevices(CancellationToken cancellationToken)
@@ -161,11 +174,22 @@ public sealed class CastingController(
 		var qrUrl = new Uri(baseUri, $"api/v1/casting/rooms/{Uri.EscapeDataString(roomId)}/qr.png?token={Uri.EscapeDataString(token)}");
 		Response.Headers["X-Tindarr-Cast-Url"] = qrUrl.ToString();
 
+		var sessionId = Guid.NewGuid().ToString();
+		var contentRuntimeSeconds = 3600; // QR is “static”; treat as 1h unless ended explicitly.
+		castingSessionStore.RegisterSession(
+			sessionId: sessionId,
+			deviceId: "sdk",
+			contentTitle: "Join room",
+			contentSubtitle: roomId,
+			contentType: "image/png",
+			contentRuntimeSeconds: contentRuntimeSeconds);
+
 		return Ok(new CastMediaUrlDto(
 			Url: qrUrl.ToString(),
 			ContentType: "image/png",
 			Title: "Join room",
-			SubTitle: roomId));
+			SubTitle: roomId,
+			SessionId: sessionId));
 	}
 
 	[HttpPost("movie")]
@@ -216,7 +240,8 @@ public sealed class CastingController(
 			return BadRequest("LAN cast base URL is not configured. Ask an admin to set LAN join address in Admin Console or configure 'BaseUrl:Lan'.");
 
 		var token = playbackTokenService.IssueMovieToken(scope, request.TmdbId, DateTimeOffset.UtcNow);
-		var playbackUrl = new Uri(baseUri, $"api/v1/playback/movie/{Uri.EscapeDataString(scope.ServiceType.ToString().ToLowerInvariant())}/{Uri.EscapeDataString(scope.ServerId)}/{request.TmdbId}?token={Uri.EscapeDataString(token)}");
+		var gatewaySessionId = Guid.NewGuid().ToString();
+		var playbackUrl = new Uri(baseUri, $"api/v1/playback/movie/{Uri.EscapeDataString(scope.ServiceType.ToString().ToLowerInvariant())}/{Uri.EscapeDataString(scope.ServerId)}/{request.TmdbId}?token={Uri.EscapeDataString(token)}&castSessionId={Uri.EscapeDataString(gatewaySessionId)}");
 		logger.LogInformation("Casting movie to device {DeviceId}: {Url}", request.DeviceId, playbackUrl);
 		Response.Headers["X-Tindarr-Cast-Url"] = playbackUrl.ToString();
 		var serverUrls = GetServerUrlsHeaderValue();
@@ -224,7 +249,6 @@ public sealed class CastingController(
 			Response.Headers["X-Tindarr-Server-Urls"] = serverUrls;
 		if (!IsServerListeningOnNonLoopback())
 			return BadRequest("API is only listening on localhost. Chromecast cannot reach it. Start the API with '--urls http://0.0.0.0:<port>' (or bind to your LAN IP) and allow the port through Windows Firewall.");
-		var gatewaySessionId = Guid.NewGuid().ToString();
 		try
 		{
 			await castClient.CastAsync(request.DeviceId, new CastMedia(
@@ -265,15 +289,27 @@ public sealed class CastingController(
 		}
 
 		var title = string.IsNullOrWhiteSpace(request.Title) ? $"TMDB:{request.TmdbId}" : request.Title.Trim();
+		var deviceId = string.IsNullOrWhiteSpace(request.DeviceId) ? "sdk" : request.DeviceId.Trim();
+		var sessionId = Guid.NewGuid().ToString();
+		var contentRuntimeSeconds = 7200; // TODO: Lookup actual runtime if available
 
 		var directUrl = await TryBuildDirectMovieCastUrlAsync(scope, request.TmdbId, cancellationToken).ConfigureAwait(false);
 		if (directUrl is not null)
 		{
+			castingSessionStore.RegisterSession(
+				sessionId: sessionId,
+				deviceId: deviceId,
+				contentTitle: title,
+				contentSubtitle: scope.ServiceType.ToString(),
+				contentType: "video/mp4",
+				contentRuntimeSeconds: contentRuntimeSeconds);
+
 			return Ok(new CastMediaUrlDto(
 				Url: directUrl.ToString(),
 				ContentType: "video/mp4",
 				Title: title,
-				SubTitle: scope.ServiceType.ToString()));
+				SubTitle: scope.ServiceType.ToString(),
+				SessionId: sessionId));
 		}
 
 		var baseUri = await ResolveCastFetchBaseUriAsync(cancellationToken).ConfigureAwait(false);
@@ -288,14 +324,23 @@ public sealed class CastingController(
 		}
 
 		var token = playbackTokenService.IssueMovieToken(scope, request.TmdbId, DateTimeOffset.UtcNow);
-		var playbackUrl = new Uri(baseUri, $"api/v1/playback/movie/{Uri.EscapeDataString(scope.ServiceType.ToString().ToLowerInvariant())}/{Uri.EscapeDataString(scope.ServerId)}/{request.TmdbId}?token={Uri.EscapeDataString(token)}");
+		var playbackUrl = new Uri(baseUri, $"api/v1/playback/movie/{Uri.EscapeDataString(scope.ServiceType.ToString().ToLowerInvariant())}/{Uri.EscapeDataString(scope.ServerId)}/{request.TmdbId}?token={Uri.EscapeDataString(token)}&castSessionId={Uri.EscapeDataString(sessionId)}");
 		Response.Headers["X-Tindarr-Cast-Url"] = playbackUrl.ToString();
+
+		castingSessionStore.RegisterSession(
+			sessionId: sessionId,
+			deviceId: deviceId,
+			contentTitle: title,
+			contentSubtitle: scope.ServiceType.ToString(),
+			contentType: "video/mp4",
+			contentRuntimeSeconds: contentRuntimeSeconds);
 
 		return Ok(new CastMediaUrlDto(
 			Url: playbackUrl.ToString(),
 			ContentType: "video/mp4",
 			Title: title,
-			SubTitle: scope.ServiceType.ToString()));
+			SubTitle: scope.ServiceType.ToString(),
+			SessionId: sessionId));
 	}
 
 	private async Task<Uri?> TryBuildDirectMovieCastUrlAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
@@ -315,9 +360,43 @@ public sealed class CastingController(
 			}
 
 			// If upstream is configured as localhost/loopback, Chromecast won't be able to reach it.
+			// Best-effort: rewrite loopback to a LAN IP so we can still return a direct URL.
 			if (IsLoopbackHost(uri.Host))
 			{
-				return null;
+				// Prefer the configured Rooms LAN host (host part only) since it's explicitly
+				// the address other devices on the LAN should use to reach this machine.
+				var joinSettings = await joinAddressSettings.GetAsync(cancellationToken).ConfigureAwait(false);
+				var lanHostPort = joinSettings?.LanHostPort?.Trim();
+				var lanHost = string.IsNullOrWhiteSpace(lanHostPort) ? null : lanHostPort.Split(':', 2, StringSplitOptions.TrimEntries)[0];
+				if (!string.IsNullOrWhiteSpace(lanHost) && !IsLoopbackHost(lanHost))
+				{
+					uri = new UriBuilder(uri)
+					{
+						Host = lanHost
+					}.Uri;
+				}
+				else
+				{
+					// Next best: the host the caller used to reach Tindarr (often already a LAN IP).
+					var requestHost = Request.Host.Host;
+					if (!string.IsNullOrWhiteSpace(requestHost) && !IsLoopbackHost(requestHost))
+					{
+						uri = new UriBuilder(uri)
+						{
+							Host = requestHost
+						}.Uri;
+					}
+					else
+					{
+						var rewritten = RewriteLoopbackToLanIp(uri, uri.Port);
+						if (rewritten is null)
+						{
+							return null;
+						}
+
+						uri = rewritten;
+					}
+				}
 			}
 
 			return uri;

--- a/src/Tindarr.Api/Controllers/EmbyController.cs
+++ b/src/Tindarr.Api/Controllers/EmbyController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Tindarr.Api.Auth;
+using Tindarr.Application.Abstractions.Persistence;
 using Tindarr.Application.Interfaces.Integrations;
 using Tindarr.Contracts.Emby;
 using Tindarr.Domain.Common;
@@ -10,7 +11,7 @@ namespace Tindarr.Api.Controllers;
 [ApiController]
 [Authorize(Policy = Policies.AdminOnly)]
 [Route("api/v1/emby")]
-public sealed class EmbyController(IEmbyService embyService) : ControllerBase
+public sealed class EmbyController(IEmbyService embyService, IServiceSettingsRepository settingsRepo) : ControllerBase
 {
 	[HttpGet("servers")]
 	public async Task<ActionResult<IReadOnlyList<EmbyServerDto>>> ListServers(CancellationToken cancellationToken)
@@ -156,5 +157,17 @@ public sealed class EmbyController(IEmbyService embyService) : ControllerBase
 			settings?.EmbyServerVersion,
 			settings?.EmbyLastLibrarySyncUtc,
 			settings?.UpdatedAtUtc);
+	}
+
+	[HttpDelete("servers/{serverId}")]
+	public async Task<IActionResult> DeleteServer([FromRoute] string serverId, CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(serverId))
+		{
+			return BadRequest("ServerId is required.");
+		}
+
+		var deleted = await settingsRepo.DeleteAsync(new ServiceScope(ServiceType.Emby, serverId.Trim()), cancellationToken);
+		return deleted ? NoContent() : NotFound("Server not found.");
 	}
 }

--- a/src/Tindarr.Api/Controllers/JellyfinController.cs
+++ b/src/Tindarr.Api/Controllers/JellyfinController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Tindarr.Api.Auth;
+using Tindarr.Application.Abstractions.Persistence;
 using Tindarr.Application.Interfaces.Integrations;
 using Tindarr.Contracts.Jellyfin;
 using Tindarr.Domain.Common;
@@ -10,7 +11,7 @@ namespace Tindarr.Api.Controllers;
 [ApiController]
 [Authorize(Policy = Policies.AdminOnly)]
 [Route("api/v1/jellyfin")]
-public sealed class JellyfinController(IJellyfinService jellyfinService) : ControllerBase
+public sealed class JellyfinController(IJellyfinService jellyfinService, IServiceSettingsRepository settingsRepo) : ControllerBase
 {
 	[HttpGet("servers")]
 	public async Task<ActionResult<IReadOnlyList<JellyfinServerDto>>> ListServers(CancellationToken cancellationToken)
@@ -156,5 +157,17 @@ public sealed class JellyfinController(IJellyfinService jellyfinService) : Contr
 			settings?.JellyfinServerVersion,
 			settings?.JellyfinLastLibrarySyncUtc,
 			settings?.UpdatedAtUtc);
+	}
+
+	[HttpDelete("servers/{serverId}")]
+	public async Task<IActionResult> DeleteServer([FromRoute] string serverId, CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(serverId))
+		{
+			return BadRequest("ServerId is required.");
+		}
+
+		var deleted = await settingsRepo.DeleteAsync(new ServiceScope(ServiceType.Jellyfin, serverId.Trim()), cancellationToken);
+		return deleted ? NoContent() : NotFound("Server not found.");
 	}
 }

--- a/src/Tindarr.Api/Controllers/PlaybackController.cs
+++ b/src/Tindarr.Api/Controllers/PlaybackController.cs
@@ -14,6 +14,7 @@ using Tindarr.Contracts.Playback;
 using Tindarr.Domain.Common;
 using Tindarr.Api.Hosting;
 using Tindarr.Infrastructure.Playback.Hls;
+using Tindarr.Infrastructure.Casting;
 
 namespace Tindarr.Api.Controllers;
 
@@ -28,7 +29,8 @@ public sealed class PlaybackController(
 	IOptions<PlexOptions> plexOptions,
 	IOptions<PlaybackOptions> playbackOptions,
 	IHttpClientFactory httpClientFactory,
-	ILogger<PlaybackController> logger) : ControllerBase
+	ILogger<PlaybackController> logger,
+	CastingSessionStore? castingSessionStore = null) : ControllerBase
 {
 	private readonly ManifestRewriter _manifestRewriter = new();
 	private readonly PlaybackOptions _playbackOptions = playbackOptions.Value;
@@ -66,20 +68,45 @@ public sealed class PlaybackController(
 	}
 
 	[HttpGet("movie/{serviceType}/{serverId}/{tmdbId:int}")]
+	[HttpHead("movie/{serviceType}/{serverId}/{tmdbId:int}")]
 	public async Task<IActionResult> StreamMovie(
 		[FromRoute] string serviceType,
 		[FromRoute] string serverId,
 		[FromRoute] int tmdbId,
 		[FromQuery] string? token,
+		[FromQuery] string? castSessionId,
 		CancellationToken cancellationToken)
 	{
+		var shouldEndSessionOnExit = false;
+		var endSessionId = string.IsNullOrWhiteSpace(castSessionId) ? null : castSessionId;
+		void EndCastSessionIfRequested()
+		{
+			if (string.IsNullOrWhiteSpace(endSessionId))
+			{
+				return;
+			}
+
+			try
+			{
+				castingSessionStore?.EndSession(endSessionId);
+			}
+			catch
+			{
+				// Best-effort only.
+			}
+		}
+
+		try
+		{
 		if (tmdbId <= 0)
 		{
+			EndCastSessionIfRequested();
 			return BadRequest("Invalid TMDB id.");
 		}
 
 		if (!ServiceScope.TryCreate(serviceType, serverId, out var scope) || scope is null)
 		{
+			EndCastSessionIfRequested();
 			return BadRequest("Invalid service scope.");
 		}
 
@@ -89,30 +116,48 @@ public sealed class PlaybackController(
 
 		if (string.IsNullOrWhiteSpace(token) || !playbackTokenService.TryValidateMovieToken(token, scope, tmdbId, DateTimeOffset.UtcNow))
 		{
+			EndCastSessionIfRequested();
 			return Unauthorized();
 		}
 
 		var provider = providers.FirstOrDefault(p => p.ServiceType == scope.ServiceType);
 		if (provider is null)
 		{
+			EndCastSessionIfRequested();
 			return BadRequest("Unsupported playback provider.");
 		}
 
 		UpstreamPlaybackRequest upstream;
 		try
 		{
-			upstream = await provider.BuildMovieStreamRequestAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+			var isCasting = !string.IsNullOrWhiteSpace(castSessionId);
+			if (isCasting && provider is ICastPlaybackProvider castProvider)
+			{
+				upstream = await castProvider.BuildMovieCastStreamRequestAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+			}
+			else
+			{
+				upstream = await provider.BuildMovieStreamRequestAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+			}
 		}
 		catch (InvalidOperationException ex)
 		{
 			logger.LogWarning(ex, "Failed to build upstream playback request. ServiceType={ServiceType} ServerId={ServerId} TmdbId={TmdbId}", scope.ServiceType, scope.ServerId, tmdbId);
+			EndCastSessionIfRequested();
 			return BadRequest(ex.Message);
 		}
 
-		logger.LogDebug("Proxying playback stream. ServiceType={ServiceType} ServerId={ServerId} TmdbId={TmdbId} UpstreamUri={UpstreamUri}", scope.ServiceType, scope.ServerId, tmdbId, upstream.Uri);
+		// Avoid logging sensitive query strings (e.g. api_key) from upstream providers.
+		logger.LogDebug(
+			"Proxying playback stream. ServiceType={ServiceType} ServerId={ServerId} TmdbId={TmdbId} UpstreamPath={UpstreamPath}",
+			scope.ServiceType,
+			scope.ServerId,
+			tmdbId,
+			upstream.Uri.GetLeftPart(UriPartial.Path));
 
 		var client = httpClientFactory.CreateClient();
-		using var upstreamRequest = new HttpRequestMessage(HttpMethod.Get, upstream.Uri);
+		var method = HttpMethods.IsHead(Request.Method) ? HttpMethod.Head : HttpMethod.Get;
+		using var upstreamRequest = new HttpRequestMessage(method, upstream.Uri);
 		StreamingProxy.CopyAllowedRequestHeaders(Request, upstreamRequest);
 		// If upstream returns a gzip'd playlist, rewriting will break. Always request identity.
 		upstreamRequest.Headers.AcceptEncoding.Clear();
@@ -128,6 +173,16 @@ public sealed class PlaybackController(
 
 		logger.LogDebug("Upstream playback response. StatusCode={StatusCode} ContentType={ContentType}", (int)upstreamResponse.StatusCode, upstreamResponse.Content.Headers.ContentType?.ToString());
 
+		// Chromecast (and some HTTP clients) will issue HEAD probes before GET.
+		// For HEAD requests, return headers only.
+		if (HttpMethods.IsHead(Request.Method))
+		{
+			Response.StatusCode = (int)upstreamResponse.StatusCode;
+			StreamingProxy.CopyAllowedResponseHeaders(upstreamResponse, Response);
+			Response.Headers.Remove(HeaderNames.ContentLength);
+			return new EmptyResult();
+		}
+
 		if (upstreamResponse.IsSuccessStatusCode && IsHlsPlaylistResponse(upstreamResponse))
 		{
 			var playlistText = await upstreamResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -138,8 +193,32 @@ public sealed class PlaybackController(
 			return Content(rewritten, upstreamResponse.Content.Headers.ContentType?.ToString() ?? "application/vnd.apple.mpegurl");
 		}
 
+		// For direct-streaming responses (non-HLS), the downstream connection lifetime closely matches playback.
+		// If the receiver disconnects early or the stream completes, we can end the cast session.
+		shouldEndSessionOnExit = true;
 		await StreamingProxy.StreamBodyAsync(upstreamResponse, Response, cancellationToken).ConfigureAwait(false);
 		return new EmptyResult();
+		}
+		catch
+		{
+			// If playback failed for a casted session, it should no longer be considered active.
+			shouldEndSessionOnExit = true;
+			throw;
+		}
+		finally
+		{
+			if (shouldEndSessionOnExit && !string.IsNullOrWhiteSpace(endSessionId))
+			{
+				try
+				{
+					castingSessionStore?.EndSession(endSessionId);
+				}
+				catch
+				{
+					// Best-effort; diagnostics cleanup should never break playback.
+				}
+			}
+		}
 	}
 
 	[HttpGet("proxy/movie/{serviceType}/{serverId}/{tmdbId:int}")]

--- a/src/Tindarr.Api/Controllers/PlexController.cs
+++ b/src/Tindarr.Api/Controllers/PlexController.cs
@@ -1,5 +1,8 @@
+using System.Text.Json;
+using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Tindarr.Api.Auth;
 using Tindarr.Api.Services;
@@ -26,8 +29,126 @@ public sealed class PlexController(
 	ITmdbMetadataStore tmdbMetadataStore,
 	ITmdbImageCache imageCache,
 	IOptions<TmdbOptions> tmdbOptions,
-	IUserPreferencesService preferencesService) : ControllerBase
+	IUserPreferencesService preferencesService,
+	IServiceSettingsRepository settingsRepo) : ControllerBase
 {
+	[Authorize(Policy = Policies.AdminOnly)]
+	[HttpGet("library/sync/status/stream")]
+	public async Task GetLibrarySyncStatusStream(
+		[FromQuery] string serviceType,
+		[FromQuery] string serverId,
+		CancellationToken cancellationToken)
+	{
+		if (!TryGetScope(serviceType, serverId, out var scope, out var errorResult))
+		{
+			Response.StatusCode = (errorResult as ObjectResult)?.StatusCode ?? StatusCodes.Status400BadRequest;
+			return;
+		}
+
+		Response.ContentType = "text/event-stream";
+		Response.Headers.CacheControl = "no-cache";
+		Response.Headers.Connection = "keep-alive";
+		Response.Headers["X-Accel-Buffering"] = "no";
+
+		var jsonOptions = HttpContext.RequestServices
+			.GetRequiredService<IOptions<JsonOptions>>()
+			.Value
+			.JsonSerializerOptions;
+
+		PlexLibrarySyncStatusDto ToDto(PlexLibrarySyncJobStatus status) => new(
+			ServiceType: status.ServiceType,
+			ServerId: status.ServerId,
+			State: status.State.ToString().ToLowerInvariant(),
+			TotalSections: status.TotalSections,
+			ProcessedSections: status.ProcessedSections,
+			TotalItems: status.TotalItems,
+			ProcessedItems: status.ProcessedItems,
+			TmdbIdsFound: status.TmdbIdsFound,
+			StartedAtUtc: status.StartedAtUtc,
+			FinishedAtUtc: status.FinishedAtUtc,
+			Message: status.Message,
+			UpdatedAtUtc: status.UpdatedAtUtc);
+
+		static async Task WriteComment(HttpResponse response, string text, CancellationToken ct)
+		{
+			await response.WriteAsync($": {text}\n\n", ct);
+			await response.Body.FlushAsync(ct);
+		}
+
+		static async Task WriteEvent(HttpResponse response, string eventName, string json, CancellationToken ct)
+		{
+			await response.WriteAsync($"event: {eventName}\n", ct);
+			await response.WriteAsync($"data: {json}\n\n", ct);
+			await response.Body.FlushAsync(ct);
+		}
+
+		var channel = Channel.CreateUnbounded<PlexLibrarySyncJobStatus>(new UnboundedChannelOptions
+		{
+			SingleReader = true,
+			SingleWriter = false
+		});
+
+		void Push(PlexLibrarySyncJobStatus status)
+		{
+			if (status.ServiceType.Equals(scope!.ServiceType.ToString().ToLowerInvariant(), StringComparison.OrdinalIgnoreCase)
+				&& status.ServerId.Equals(scope.ServerId, StringComparison.OrdinalIgnoreCase))
+			{
+				channel.Writer.TryWrite(status);
+			}
+		}
+
+		EventHandler<PlexLibrarySyncJobStatus> handler = (_, status) => Push(status);
+		librarySyncJob.StatusChanged += handler;
+
+		var keepAliveInterval = TimeSpan.FromSeconds(15);
+
+		try
+		{
+			var initial = librarySyncJob.GetStatus(scope!);
+			await WriteEvent(Response, "status", JsonSerializer.Serialize(ToDto(initial), jsonOptions), cancellationToken);
+
+			// If nothing is running, we can close the stream after emitting the snapshot.
+			if (initial.State != PlexLibrarySyncJobState.Running)
+			{
+				return;
+			}
+
+			while (!cancellationToken.IsCancellationRequested)
+			{
+				var delayTask = Task.Delay(keepAliveInterval, cancellationToken);
+				var readTask = channel.Reader.ReadAsync(cancellationToken).AsTask();
+				var completed = await Task.WhenAny(delayTask, readTask).ConfigureAwait(false);
+
+				if (completed == delayTask)
+				{
+					await WriteComment(Response, "keepalive", cancellationToken);
+					continue;
+				}
+
+				var next = await readTask.ConfigureAwait(false);
+				// Drain any queued statuses; only emit the latest.
+				while (channel.Reader.TryRead(out var extra))
+				{
+					next = extra;
+				}
+
+				await WriteEvent(Response, "status", JsonSerializer.Serialize(ToDto(next), jsonOptions), cancellationToken);
+				if (next.State != PlexLibrarySyncJobState.Running)
+				{
+					return;
+				}
+			}
+		}
+		catch (OperationCanceledException)
+		{
+			// client disconnected
+		}
+		finally
+		{
+			librarySyncJob.StatusChanged -= handler;
+		}
+	}
+
 	[Authorize(Policy = Policies.AdminOnly)]
 	[HttpGet("auth/status")]
 	public async Task<ActionResult<PlexAuthStatusResponse>> GetAuthStatus(CancellationToken cancellationToken)
@@ -105,6 +226,24 @@ public sealed class PlexController(
 		{
 			return StatusCode(StatusCodes.Status504GatewayTimeout, "Plex request timed out.");
 		}
+	}
+
+	[Authorize(Policy = Policies.AdminOnly)]
+	[HttpDelete("servers/{serverId}")]
+	public async Task<IActionResult> DeleteServer([FromRoute] string serverId, CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(serverId))
+		{
+			return BadRequest("ServerId is required.");
+		}
+
+		if (string.Equals(serverId, PlexConstants.AccountServerId, StringComparison.OrdinalIgnoreCase))
+		{
+			return BadRequest("Cannot delete plex-account settings.");
+		}
+
+		var deleted = await settingsRepo.DeleteAsync(new ServiceScope(ServiceType.Plex, serverId.Trim()), cancellationToken);
+		return deleted ? NoContent() : NotFound("Server not found.");
 	}
 
 	[Authorize(Policy = Policies.AdminOnly)]

--- a/src/Tindarr.Api/Controllers/RoomsController.cs
+++ b/src/Tindarr.Api/Controllers/RoomsController.cs
@@ -232,7 +232,7 @@ public sealed class RoomsController(
 				return NotFound("Room not found.");
 			}
 
-			var cards = await roomService.GetSwipeDeckAsync(roomId, userId, Math.Clamp(limit, 1, 50), cancellationToken);
+			var cards = await roomService.GetSwipeDeckAsync(roomId, userId, Math.Clamp(limit, 10, 50), cancellationToken);
 			var response = new SwipeDeckResponse(
 				room.Scope.ServiceType.ToString().ToLowerInvariant(),
 				room.Scope.ServerId,

--- a/src/Tindarr.Api/Controllers/SwipeDeckController.cs
+++ b/src/Tindarr.Api/Controllers/SwipeDeckController.cs
@@ -24,7 +24,7 @@ public sealed class SwipeDeckController(ISwipeDeckService swipeDeckService) : Co
         try
         {
             var userId = User.GetUserId();
-            var cards = await swipeDeckService.GetDeckAsync(userId, scope!, Math.Clamp(limit, 1, 50), cancellationToken);
+            var cards = await swipeDeckService.GetDeckAsync(userId, scope!, Math.Clamp(limit, 10, 50), cancellationToken);
             var response = new SwipeDeckResponse(scope!.ServiceType.ToString().ToLowerInvariant(), scope.ServerId, cards.Select(Map).ToList());
 
             return Ok(response);

--- a/src/Tindarr.Api/Services/PlexLibrarySyncJobService.cs
+++ b/src/Tindarr.Api/Services/PlexLibrarySyncJobService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Tindarr.Application.Interfaces.Integrations;
 using Tindarr.Domain.Common;
@@ -29,15 +30,19 @@ public sealed record PlexLibrarySyncJobStatus(
 
 public interface IPlexLibrarySyncJobService
 {
+	event EventHandler<PlexLibrarySyncJobStatus>? StatusChanged;
 	PlexLibrarySyncJobStatus GetStatus(ServiceScope scope);
 	Task<PlexLibrarySyncJobStatus> StartAsync(ServiceScope scope, CancellationToken cancellationToken);
 }
 
 public sealed class PlexLibrarySyncJobService(IServiceScopeFactory scopeFactory) : IPlexLibrarySyncJobService
 {
+	public event EventHandler<PlexLibrarySyncJobStatus>? StatusChanged;
+
 	private sealed class JobEntry
 	{
 		public readonly SemaphoreSlim Gate = new(1, 1);
+		public long LastPublishAtUnixMs = 0;
 		public PlexLibrarySyncJobStatus Status = new(
 			ServiceType: "plex",
 			ServerId: "default",
@@ -56,6 +61,30 @@ public sealed class PlexLibrarySyncJobService(IServiceScopeFactory scopeFactory)
 	private readonly ConcurrentDictionary<string, JobEntry> _jobs = new(StringComparer.OrdinalIgnoreCase);
 
 	private static string Key(ServiceScope scope) => $"{scope.ServiceType}:{scope.ServerId}";
+
+	private void Publish(JobEntry entry, PlexLibrarySyncJobStatus status, bool force = false)
+	{
+		if (StatusChanged is null) return;
+
+		var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+		if (!force)
+		{
+			var last = Interlocked.Read(ref entry.LastPublishAtUnixMs);
+			if (nowMs - last < 250)
+			{
+				return;
+			}
+
+			// Best-effort: allow one publisher through at a time.
+			Interlocked.Exchange(ref entry.LastPublishAtUnixMs, nowMs);
+		}
+		else
+		{
+			Interlocked.Exchange(ref entry.LastPublishAtUnixMs, nowMs);
+		}
+
+		StatusChanged?.Invoke(this, status);
+	}
 
 	public PlexLibrarySyncJobStatus GetStatus(ServiceScope scope)
 	{
@@ -90,6 +119,7 @@ public sealed class PlexLibrarySyncJobService(IServiceScopeFactory scopeFactory)
 				Message = null,
 				UpdatedAtUtc = startedAt
 			};
+			Publish(entry, entry.Status, force: true);
 
 			_ = Task.Run(async () =>
 			{
@@ -105,6 +135,7 @@ public sealed class PlexLibrarySyncJobService(IServiceScopeFactory scopeFactory)
 						Message = string.IsNullOrWhiteSpace(p.CurrentSectionTitle) ? "Syncing…" : $"Syncing: {p.CurrentSectionTitle}",
 						UpdatedAtUtc = DateTimeOffset.UtcNow
 					};
+					Publish(entry, entry.Status);
 				});
 
 				try
@@ -120,6 +151,7 @@ public sealed class PlexLibrarySyncJobService(IServiceScopeFactory scopeFactory)
 						Message = "Sync complete.",
 						UpdatedAtUtc = finishedAt
 					};
+					Publish(entry, entry.Status, force: true);
 				}
 				catch (Exception ex)
 				{
@@ -131,6 +163,7 @@ public sealed class PlexLibrarySyncJobService(IServiceScopeFactory scopeFactory)
 						Message = ex.Message,
 						UpdatedAtUtc = finishedAt
 					};
+					Publish(entry, entry.Status, force: true);
 				}
 			});
 

--- a/src/Tindarr.Application/Abstractions/Persistence/IServiceSettingsRepository.cs
+++ b/src/Tindarr.Application/Abstractions/Persistence/IServiceSettingsRepository.cs
@@ -9,6 +9,8 @@ public interface IServiceSettingsRepository
 	Task<IReadOnlyList<ServiceSettingsRecord>> ListAsync(ServiceType serviceType, CancellationToken cancellationToken);
 
 	Task UpsertAsync(ServiceScope scope, ServiceSettingsUpsert upsert, CancellationToken cancellationToken);
+
+	Task<bool> DeleteAsync(ServiceScope scope, CancellationToken cancellationToken);
 }
 
 public sealed record ServiceSettingsRecord(

--- a/src/Tindarr.Application/Interfaces/Playback/IPlaybackProvider.cs
+++ b/src/Tindarr.Application/Interfaces/Playback/IPlaybackProvider.cs
@@ -23,6 +23,16 @@ public interface IDirectPlaybackProvider : IPlaybackProvider
 	Task<Uri?> TryBuildDirectMovieStreamUrlAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken);
 }
 
+/// <summary>
+/// Optional extension for providers that can build a cast-optimized stream request.
+/// This is used when the consumer is a Chromecast receiver, which often requires
+/// a more compatible audio codec/container than normal in-browser playback.
+/// </summary>
+public interface ICastPlaybackProvider : IPlaybackProvider
+{
+	Task<UpstreamPlaybackRequest> BuildMovieCastStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken);
+}
+
 public sealed record UpstreamPlaybackRequest(
 	Uri Uri,
 	IReadOnlyDictionary<string, string> Headers);

--- a/src/Tindarr.Contracts/Casting/CastMediaUrlDto.cs
+++ b/src/Tindarr.Contracts/Casting/CastMediaUrlDto.cs
@@ -4,4 +4,5 @@ public sealed record CastMediaUrlDto(
 	string Url,
 	string ContentType,
 	string Title,
-	string? SubTitle);
+	string? SubTitle,
+	string? SessionId = null);

--- a/src/Tindarr.Contracts/Casting/GetMovieCastUrlRequest.cs
+++ b/src/Tindarr.Contracts/Casting/GetMovieCastUrlRequest.cs
@@ -4,4 +4,5 @@ public sealed record GetMovieCastUrlRequest(
 	string ServiceType,
 	string ServerId,
 	int TmdbId,
-	string? Title);
+	string? Title,
+	string? DeviceId = null);

--- a/src/Tindarr.Infrastructure/Casting/CastingSessionStore.cs
+++ b/src/Tindarr.Infrastructure/Casting/CastingSessionStore.cs
@@ -30,6 +30,10 @@ public sealed class CastingSessionStore(IMemoryCache cache)
 		string contentType,
 		int contentRuntimeSeconds)
 	{
+		// If a device starts a new cast, consider the previous session ended.
+		// This keeps diagnostics accurate even when the receiver never calls back (e.g. user stops early).
+		EndOtherSessionsForDevice(deviceId, exceptSessionId: sessionId);
+
 		var expiresAt = DateTime.UtcNow.AddSeconds(contentRuntimeSeconds + 120);
 
 		var session = new CastingSessionDto(
@@ -61,6 +65,36 @@ public sealed class CastingSessionStore(IMemoryCache cache)
 			ErrorDetails: null));
 
 		SessionStarted?.Invoke(this, new CastingEventArgs(sessionId, deviceId));
+	}
+
+	private void EndOtherSessionsForDevice(string deviceId, string exceptSessionId)
+	{
+		if (string.IsNullOrWhiteSpace(deviceId))
+		{
+			return;
+		}
+
+		HashSet<string> sessionIds;
+		lock (_lock)
+		{
+			sessionIds = LoadSessionIndexNoLock();
+		}
+
+		foreach (var id in sessionIds)
+		{
+			if (string.Equals(id, exceptSessionId, StringComparison.Ordinal))
+			{
+				continue;
+			}
+
+			var key = $"{SessionKeyPrefix}{id}";
+			if (cache.TryGetValue(key, out CastingSessionDto? session)
+				&& session is not null
+				&& string.Equals(session.DeviceId, deviceId, StringComparison.Ordinal))
+			{
+				EndSession(id);
+			}
+		}
 	}
 
 	/// <summary>

--- a/src/Tindarr.Infrastructure/Integrations/Emby/EmbySwipeDeckSource.cs
+++ b/src/Tindarr.Infrastructure/Integrations/Emby/EmbySwipeDeckSource.cs
@@ -1,8 +1,10 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Tindarr.Application.Abstractions.Integrations;
 using Tindarr.Application.Abstractions.Persistence;
 using Tindarr.Application.Interfaces.Interactions;
 using Tindarr.Contracts.Movies;
+using Tindarr.Application.Options;
 using Tindarr.Domain.Common;
 using Tindarr.Domain.Interactions;
 
@@ -11,8 +13,14 @@ namespace Tindarr.Infrastructure.Integrations.Emby;
 public sealed class EmbySwipeDeckSource(
 	ILibraryCacheRepository libraryCache,
 	ITmdbClient tmdbClient,
+	ITmdbMetadataStore metadataStore,
+	IOptions<TmdbOptions> tmdbOptions,
+	IInteractionStore interactionStore,
 	ILogger<EmbySwipeDeckSource> logger) : ISwipeDeckSource
 {
+	private const int CandidateLimit = 80;
+	private const int DetailLookupBudget = 10;
+
 	public async Task<IReadOnlyList<SwipeCard>> GetCandidatesAsync(string userId, ServiceScope scope, CancellationToken cancellationToken)
 	{
 		var ids = await libraryCache.GetTmdbIdsAsync(scope, cancellationToken).ConfigureAwait(false);
@@ -21,37 +29,150 @@ public sealed class EmbySwipeDeckSource(
 			throw new InvalidOperationException("Emby library is not synced yet. Sync the Emby library in Admin Console, then try again.");
 		}
 
-		var candidateIds = ids.Take(80).ToList();
-		var cards = new List<SwipeCard>(capacity: candidateIds.Count);
+		var interacted = await interactionStore.GetInteractedTmdbIdsAsync(userId, scope, cancellationToken).ConfigureAwait(false);
+		var interactedSet = interacted as HashSet<int> ?? interacted.ToHashSet();
+		var candidateIds = ids
+			.Where(id => id > 0 && !interactedSet.Contains(id))
+			.Take(250)
+			.ToList();
+
+		var settings = await metadataStore.GetSettingsAsync(cancellationToken).ConfigureAwait(false);
+		var tmdb = tmdbOptions.Value;
+		var canLookup = tmdb.HasCredentials;
+
+		var cards = new List<SwipeCard>(capacity: CandidateLimit);
+		var lookupIds = new List<int>(capacity: DetailLookupBudget);
 
 		foreach (var id in candidateIds)
 		{
-			MovieDetailsDto? details;
-			try
+			if (cards.Count + lookupIds.Count >= CandidateLimit)
 			{
-				details = await tmdbClient.GetMovieDetailsAsync(id, cancellationToken).ConfigureAwait(false);
+				break;
 			}
-			catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+
+			var stored = await metadataStore.GetMovieAsync(id, cancellationToken).ConfigureAwait(false);
+			if (stored is not null)
 			{
-				logger.LogDebug(ex, "tmdb details lookup failed for emby candidate. TmdbId={TmdbId}", id);
+				cards.Add(new SwipeCard(
+					TmdbId: id,
+					Title: (stored.Title ?? $"TMDB:{id}").Trim(),
+					Overview: stored.Overview,
+					PosterUrl: BuildImageUrl(settings, tmdb.ImageBaseUrl, stored.PosterPath, tmdb.PosterSize),
+					BackdropUrl: BuildImageUrl(settings, tmdb.ImageBaseUrl, stored.BackdropPath, tmdb.BackdropSize),
+					ReleaseYear: stored.ReleaseYear,
+					Rating: stored.Rating));
 				continue;
 			}
 
-			if (details is null)
+			if (canLookup && lookupIds.Count < DetailLookupBudget)
 			{
+				lookupIds.Add(id);
 				continue;
 			}
 
 			cards.Add(new SwipeCard(
-				TmdbId: details.TmdbId,
-				Title: details.Title,
-				Overview: details.Overview,
-				PosterUrl: details.PosterUrl,
-				BackdropUrl: details.BackdropUrl,
-				ReleaseYear: details.ReleaseYear,
-				Rating: details.Rating));
+				TmdbId: id,
+				Title: $"TMDB:{id}",
+				Overview: null,
+				PosterUrl: null,
+				BackdropUrl: null,
+				ReleaseYear: null,
+				Rating: null));
 		}
 
-		return cards;
+		if (lookupIds.Count > 0)
+		{
+			var lookupTasks = lookupIds.Select(async id =>
+			{
+				MovieDetailsDto? details;
+				try
+				{
+					details = await tmdbClient.GetMovieDetailsAsync(id, cancellationToken).ConfigureAwait(false);
+				}
+				catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+				{
+					logger.LogDebug(ex, "tmdb details lookup failed for emby candidate. TmdbId={TmdbId}", id);
+					return new SwipeCard(
+						TmdbId: id,
+						Title: $"TMDB:{id}",
+						Overview: null,
+						PosterUrl: null,
+						BackdropUrl: null,
+						ReleaseYear: null,
+						Rating: null);
+				}
+
+				if (details is null)
+				{
+					return new SwipeCard(
+						TmdbId: id,
+						Title: $"TMDB:{id}",
+						Overview: null,
+						PosterUrl: null,
+						BackdropUrl: null,
+						ReleaseYear: null,
+						Rating: null);
+				}
+
+				try
+				{
+					await metadataStore.UpdateMovieDetailsAsync(details, cancellationToken).ConfigureAwait(false);
+				}
+				catch (Exception ex)
+				{
+					logger.LogDebug(ex, "failed to persist tmdb details after emby swipedeck lookup. TmdbId={TmdbId}", id);
+				}
+
+				return new SwipeCard(
+					TmdbId: details.TmdbId,
+					Title: details.Title,
+					Overview: details.Overview,
+					PosterUrl: details.PosterUrl,
+					BackdropUrl: details.BackdropUrl,
+					ReleaseYear: details.ReleaseYear,
+					Rating: details.Rating);
+			}).ToArray();
+
+			var lookedUp = await Task.WhenAll(lookupTasks).ConfigureAwait(false);
+			var lookedUpIds = new HashSet<int>();
+			foreach (var c in lookedUp)
+			{
+				if (lookedUpIds.Add(c.TmdbId))
+				{
+					cards.Insert(0, c);
+				}
+			}
+		}
+
+		var seen = new HashSet<int>();
+		return cards.Where(c => seen.Add(c.TmdbId)).ToList();
+	}
+
+	private static string? BuildImageUrl(TmdbMetadataSettings settings, string imageBaseUrl, string? path, string size)
+	{
+		if (string.IsNullOrWhiteSpace(path))
+		{
+			return null;
+		}
+
+		var normalizedPath = path.Trim();
+		if (normalizedPath.StartsWith('/'))
+		{
+			normalizedPath = normalizedPath.TrimStart('/');
+		}
+
+		var normalizedSize = (size ?? string.Empty).Trim().Trim('/');
+		if (string.IsNullOrWhiteSpace(normalizedSize))
+		{
+			normalizedSize = "original";
+		}
+
+		if (settings.PosterMode == TmdbPosterMode.LocalProxy && settings.ImageCacheMaxMb > 0)
+		{
+			return $"/api/v1/tmdb/images/{normalizedSize}/{normalizedPath}";
+		}
+
+		var normalizedBase = (imageBaseUrl ?? string.Empty).TrimEnd('/');
+		return $"{normalizedBase}/{normalizedSize}/{normalizedPath}";
 	}
 }

--- a/src/Tindarr.Infrastructure/Integrations/Jellyfin/JellyfinSwipeDeckSource.cs
+++ b/src/Tindarr.Infrastructure/Integrations/Jellyfin/JellyfinSwipeDeckSource.cs
@@ -1,8 +1,10 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Tindarr.Application.Abstractions.Integrations;
 using Tindarr.Application.Abstractions.Persistence;
 using Tindarr.Application.Interfaces.Interactions;
 using Tindarr.Contracts.Movies;
+using Tindarr.Application.Options;
 using Tindarr.Domain.Common;
 using Tindarr.Domain.Interactions;
 
@@ -11,8 +13,14 @@ namespace Tindarr.Infrastructure.Integrations.Jellyfin;
 public sealed class JellyfinSwipeDeckSource(
 	ILibraryCacheRepository libraryCache,
 	ITmdbClient tmdbClient,
+	ITmdbMetadataStore metadataStore,
+	IOptions<TmdbOptions> tmdbOptions,
+	IInteractionStore interactionStore,
 	ILogger<JellyfinSwipeDeckSource> logger) : ISwipeDeckSource
 {
+	private const int CandidateLimit = 80;
+	private const int DetailLookupBudget = 10;
+
 	public async Task<IReadOnlyList<SwipeCard>> GetCandidatesAsync(string userId, ServiceScope scope, CancellationToken cancellationToken)
 	{
 		var ids = await libraryCache.GetTmdbIdsAsync(scope, cancellationToken).ConfigureAwait(false);
@@ -21,38 +29,154 @@ public sealed class JellyfinSwipeDeckSource(
 			throw new InvalidOperationException("Jellyfin library is not synced yet. Sync the Jellyfin library in Admin Console, then try again.");
 		}
 
-		// Pull a modest candidate set and let SwipeDeckService filter out swiped items.
-		var candidateIds = ids.Take(80).ToList();
-		var cards = new List<SwipeCard>(capacity: candidateIds.Count);
+		var interacted = await interactionStore.GetInteractedTmdbIdsAsync(userId, scope, cancellationToken).ConfigureAwait(false);
+		var interactedSet = interacted as HashSet<int> ?? interacted.ToHashSet();
+		var candidateIds = ids
+			.Where(id => id > 0 && !interactedSet.Contains(id))
+			.Take(250)
+			.ToList();
+
+		// Build cards from the local metadata store when possible (fast), and only do a small
+		// budget of network lookups so we can return a usable deck quickly.
+		var settings = await metadataStore.GetSettingsAsync(cancellationToken).ConfigureAwait(false);
+		var tmdb = tmdbOptions.Value;
+		var canLookup = tmdb.HasCredentials;
+
+		var cards = new List<SwipeCard>(capacity: CandidateLimit);
+		var lookupIds = new List<int>(capacity: DetailLookupBudget);
 
 		foreach (var id in candidateIds)
 		{
-			MovieDetailsDto? details;
-			try
+			if (cards.Count + lookupIds.Count >= CandidateLimit)
 			{
-				details = await tmdbClient.GetMovieDetailsAsync(id, cancellationToken).ConfigureAwait(false);
+				break;
 			}
-			catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+
+			var stored = await metadataStore.GetMovieAsync(id, cancellationToken).ConfigureAwait(false);
+			if (stored is not null)
 			{
-				logger.LogDebug(ex, "tmdb details lookup failed for jellyfin candidate. TmdbId={TmdbId}", id);
+				cards.Add(new SwipeCard(
+					TmdbId: id,
+					Title: (stored.Title ?? $"TMDB:{id}").Trim(),
+					Overview: stored.Overview,
+					PosterUrl: BuildImageUrl(settings, tmdb.ImageBaseUrl, stored.PosterPath, tmdb.PosterSize),
+					BackdropUrl: BuildImageUrl(settings, tmdb.ImageBaseUrl, stored.BackdropPath, tmdb.BackdropSize),
+					ReleaseYear: stored.ReleaseYear,
+					Rating: stored.Rating));
 				continue;
 			}
 
-			if (details is null)
+			if (canLookup && lookupIds.Count < DetailLookupBudget)
 			{
+				lookupIds.Add(id);
 				continue;
 			}
 
 			cards.Add(new SwipeCard(
-				TmdbId: details.TmdbId,
-				Title: details.Title,
-				Overview: details.Overview,
-				PosterUrl: details.PosterUrl,
-				BackdropUrl: details.BackdropUrl,
-				ReleaseYear: details.ReleaseYear,
-				Rating: details.Rating));
+				TmdbId: id,
+				Title: $"TMDB:{id}",
+				Overview: null,
+				PosterUrl: null,
+				BackdropUrl: null,
+				ReleaseYear: null,
+				Rating: null));
 		}
 
-		return cards;
+		if (lookupIds.Count > 0)
+		{
+			var lookupTasks = lookupIds.Select(async id =>
+			{
+				MovieDetailsDto? details;
+				try
+				{
+					details = await tmdbClient.GetMovieDetailsAsync(id, cancellationToken).ConfigureAwait(false);
+				}
+				catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+				{
+					logger.LogDebug(ex, "tmdb details lookup failed for jellyfin candidate. TmdbId={TmdbId}", id);
+					return new SwipeCard(
+						TmdbId: id,
+						Title: $"TMDB:{id}",
+						Overview: null,
+						PosterUrl: null,
+						BackdropUrl: null,
+						ReleaseYear: null,
+						Rating: null);
+				}
+
+				if (details is null)
+				{
+					return new SwipeCard(
+						TmdbId: id,
+						Title: $"TMDB:{id}",
+						Overview: null,
+						PosterUrl: null,
+						BackdropUrl: null,
+						ReleaseYear: null,
+						Rating: null);
+				}
+
+				try
+				{
+					await metadataStore.UpdateMovieDetailsAsync(details, cancellationToken).ConfigureAwait(false);
+				}
+				catch (Exception ex)
+				{
+					logger.LogDebug(ex, "failed to persist tmdb details after jellyfin swipedeck lookup. TmdbId={TmdbId}", id);
+				}
+
+				return new SwipeCard(
+					TmdbId: details.TmdbId,
+					Title: details.Title,
+					Overview: details.Overview,
+					PosterUrl: details.PosterUrl,
+					BackdropUrl: details.BackdropUrl,
+					ReleaseYear: details.ReleaseYear,
+					Rating: details.Rating);
+			}).ToArray();
+
+			var lookedUp = await Task.WhenAll(lookupTasks).ConfigureAwait(false);
+			// Put looked-up cards first so the initial deck has richer cards.
+			var lookedUpIds = new HashSet<int>();
+			foreach (var c in lookedUp)
+			{
+				if (lookedUpIds.Add(c.TmdbId))
+				{
+					cards.Insert(0, c);
+				}
+			}
+		}
+
+		// Deduplicate while preserving order.
+		var seen = new HashSet<int>();
+		return cards.Where(c => seen.Add(c.TmdbId)).ToList();
+	}
+
+	private static string? BuildImageUrl(TmdbMetadataSettings settings, string imageBaseUrl, string? path, string size)
+	{
+		if (string.IsNullOrWhiteSpace(path))
+		{
+			return null;
+		}
+
+		var normalizedPath = path.Trim();
+		if (normalizedPath.StartsWith('/'))
+		{
+			normalizedPath = normalizedPath.TrimStart('/');
+		}
+
+		var normalizedSize = (size ?? string.Empty).Trim().Trim('/');
+		if (string.IsNullOrWhiteSpace(normalizedSize))
+		{
+			normalizedSize = "original";
+		}
+
+		if (settings.PosterMode == TmdbPosterMode.LocalProxy && settings.ImageCacheMaxMb > 0)
+		{
+			return $"/api/v1/tmdb/images/{normalizedSize}/{normalizedPath}";
+		}
+
+		var normalizedBase = (imageBaseUrl ?? string.Empty).TrimEnd('/');
+		return $"{normalizedBase}/{normalizedSize}/{normalizedPath}";
 	}
 }

--- a/src/Tindarr.Infrastructure/Persistence/Repositories/ServiceSettingsRepository.cs
+++ b/src/Tindarr.Infrastructure/Persistence/Repositories/ServiceSettingsRepository.cs
@@ -119,6 +119,21 @@ public sealed class ServiceSettingsRepository(TindarrDbContext db) : IServiceSet
 		await db.SaveChangesAsync(cancellationToken);
 	}
 
+	public async Task<bool> DeleteAsync(ServiceScope scope, CancellationToken cancellationToken)
+	{
+		var entity = await db.ServiceSettings
+			.SingleOrDefaultAsync(x => x.ServiceType == scope.ServiceType && x.ServerId == scope.ServerId, cancellationToken);
+
+		if (entity is null)
+		{
+			return false;
+		}
+
+		db.ServiceSettings.Remove(entity);
+		await db.SaveChangesAsync(cancellationToken);
+		return true;
+	}
+
 	private static ServiceSettingsRecord Map(ServiceSettingsEntity entity)
 	{
 		return new ServiceSettingsRecord(

--- a/src/Tindarr.Infrastructure/Playback/Providers/EmbyPlaybackProvider.cs
+++ b/src/Tindarr.Infrastructure/Playback/Providers/EmbyPlaybackProvider.cs
@@ -1,6 +1,7 @@
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Tindarr.Application.Abstractions.Persistence;
 using Tindarr.Application.Interfaces.Playback;
@@ -12,7 +13,7 @@ public sealed class EmbyPlaybackProvider(
 	IServiceSettingsRepository settingsRepo,
 	ICastingSettingsRepository castingSettingsRepo,
 	HttpClient httpClient,
-	ILogger<EmbyPlaybackProvider> logger) : IDirectPlaybackProvider
+	ILogger<EmbyPlaybackProvider> logger) : IDirectPlaybackProvider, ICastPlaybackProvider
 {
 	private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
 
@@ -20,16 +21,99 @@ public sealed class EmbyPlaybackProvider(
 
 	public async Task<Uri?> TryBuildDirectMovieStreamUrlAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
 	{
-		var upstream = await BuildMovieStreamRequestAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+		// Direct URLs are only used for cast devices; prefer a cast-compatible request.
+		var upstream = await BuildMovieCastStreamRequestAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
 		if (!upstream.Headers.TryGetValue("X-Emby-Token", out var token) || string.IsNullOrWhiteSpace(token))
 		{
 			return null;
 		}
 
-		return AppendOrReplaceQuery(upstream.Uri, "api_key", token);
+		// Cast devices can't send headers; include token in query.
+		var uri = AppendOrReplaceQuery(upstream.Uri, "api_key", token);
+		uri = AppendOrReplaceQuery(uri, "X-Emby-Token", token);
+		return uri;
 	}
 
 	public async Task<UpstreamPlaybackRequest> BuildMovieStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
+	{
+		var (baseUrl, apiKey, _userId, itemId, streamSelection) = await ResolveContextAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+
+		var queryParts = new List<string>(capacity: 10)
+		{
+			$"api_key={Uri.EscapeDataString(apiKey)}",
+			"Static=true"
+		};
+		if (streamSelection.AudioStreamIndex is not null)
+		{
+			queryParts.Add($"AudioStreamIndex={streamSelection.AudioStreamIndex.Value}");
+		}
+		if (streamSelection.SubtitleStreamIndex is not null)
+		{
+			queryParts.Add($"SubtitleStreamIndex={streamSelection.SubtitleStreamIndex.Value}");
+		}
+		if (!string.IsNullOrWhiteSpace(streamSelection.SubtitleMethod))
+		{
+			queryParts.Add($"SubtitleMethod={Uri.EscapeDataString(streamSelection.SubtitleMethod!)}");
+		}
+
+		var upstreamUri = new Uri($"{baseUrl}Videos/{Uri.EscapeDataString(itemId)}/stream?{string.Join("&", queryParts)}", UriKind.Absolute);
+		return new UpstreamPlaybackRequest(
+			Uri: upstreamUri,
+			Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+			{
+				["X-Emby-Token"] = apiKey
+			});
+	}
+
+	public async Task<UpstreamPlaybackRequest> BuildMovieCastStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
+	{
+		var (baseUrl, apiKey, userId, itemId, streamSelection) = await ResolveContextAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+		var mediaSourceId = await TryGetMediaSourceIdAsync(httpClient, baseUrl, apiKey, userId, itemId, cancellationToken).ConfigureAwait(false);
+
+		// Chromecast audio decoding is more limited than Emby's normal web clients.
+		// Force an mp4 container + AAC audio, and cap channels to stereo as a safe default.
+		var queryParts = new List<string>(capacity: 16)
+		{
+			$"api_key={Uri.EscapeDataString(apiKey)}",
+			"Static=false",
+			"AudioCodec=aac",
+			"MaxAudioChannels=2",
+			$"DeviceId={Uri.EscapeDataString(BuildCastDeviceId(scope))}",
+			"VideoCodec=h264",
+			"MaxWidth=1920",
+			"MaxHeight=1080",
+			"VideoBitRate=8000000"
+		};
+		if (!string.IsNullOrWhiteSpace(mediaSourceId))
+		{
+			queryParts.Add($"MediaSourceId={Uri.EscapeDataString(mediaSourceId)}");
+		}
+		if (streamSelection.AudioStreamIndex is not null)
+		{
+			queryParts.Add($"AudioStreamIndex={streamSelection.AudioStreamIndex.Value}");
+		}
+		// IMPORTANT: MP4 cannot mux common text subtitle codecs (e.g. SRT/subrip).
+		// Only request subtitles when we are burning them into video (Encode).
+		if (streamSelection.SubtitleStreamIndex is not null
+			&& string.Equals(streamSelection.SubtitleMethod, "Encode", StringComparison.OrdinalIgnoreCase))
+		{
+			queryParts.Add($"SubtitleStreamIndex={streamSelection.SubtitleStreamIndex.Value}");
+			queryParts.Add("SubtitleMethod=Encode");
+		}
+
+		var upstreamUri = new Uri($"{baseUrl}Videos/{Uri.EscapeDataString(itemId)}/stream.mp4?{string.Join("&", queryParts)}", UriKind.Absolute);
+		return new UpstreamPlaybackRequest(
+			Uri: upstreamUri,
+			Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+			{
+				["X-Emby-Token"] = apiKey
+			});
+	}
+
+	private async Task<(string BaseUrl, string ApiKey, string UserId, string ItemId, StreamSelection StreamSelection)> ResolveContextAsync(
+		ServiceScope scope,
+		int tmdbId,
+		CancellationToken cancellationToken)
 	{
 		var settings = await settingsRepo.GetAsync(scope, cancellationToken).ConfigureAwait(false);
 		if (settings is null || string.IsNullOrWhiteSpace(settings.EmbyBaseUrl) || string.IsNullOrWhiteSpace(settings.EmbyApiKey))
@@ -55,27 +139,42 @@ public sealed class EmbyPlaybackProvider(
 		var castingSettings = await castingSettingsRepo.GetAsync(cancellationToken).ConfigureAwait(false);
 		var streamSelection = await TrySelectStreamsAsync(httpClient, baseUrl, apiKey, userId, itemId, castingSettings, cancellationToken).ConfigureAwait(false);
 
-		var queryParts = new List<string>(capacity: 8) { "static=true" };
-		if (streamSelection.AudioStreamIndex is not null)
+		return (baseUrl, apiKey, userId, itemId, streamSelection);
+	}
+
+	private static string BuildCastDeviceId(ServiceScope scope)
+	{
+		var serverId = (scope.ServerId ?? string.Empty).Trim();
+		if (string.IsNullOrWhiteSpace(serverId))
 		{
-			queryParts.Add($"AudioStreamIndex={streamSelection.AudioStreamIndex.Value}");
-		}
-		if (streamSelection.SubtitleStreamIndex is not null)
-		{
-			queryParts.Add($"SubtitleStreamIndex={streamSelection.SubtitleStreamIndex.Value}");
-		}
-		if (!string.IsNullOrWhiteSpace(streamSelection.SubtitleMethod))
-		{
-			queryParts.Add($"SubtitleMethod={Uri.EscapeDataString(streamSelection.SubtitleMethod!)}");
+			return "tindarr-cast";
 		}
 
-		var upstreamUri = new Uri($"{baseUrl}Videos/{Uri.EscapeDataString(itemId)}/stream?{string.Join("&", queryParts)}", UriKind.Absolute);
-		return new UpstreamPlaybackRequest(
-			Uri: upstreamUri,
-			Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-			{
-				["X-Emby-Token"] = apiKey
-			});
+		return $"tindarr-cast:{serverId}";
+	}
+
+	private static async Task<string?> TryGetMediaSourceIdAsync(
+		HttpClient client,
+		string baseUrl,
+		string apiKey,
+		string userId,
+		string itemId,
+		CancellationToken cancellationToken)
+	{
+		var uri = new Uri($"{baseUrl}Items/{Uri.EscapeDataString(itemId)}/PlaybackInfo?UserId={Uri.EscapeDataString(userId)}", UriKind.Absolute);
+		using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+		request.Headers.Accept.ParseAdd("application/json");
+		request.Headers.Add("X-Emby-Token", apiKey);
+		using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+		if (!response.IsSuccessStatusCode)
+		{
+			return null;
+		}
+
+		var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+		var dto = JsonSerializer.Deserialize<PlaybackInfoResponseDto>(json, Json);
+		var id = dto?.MediaSources?.FirstOrDefault(ms => !string.IsNullOrWhiteSpace(ms.Id))?.Id;
+		return string.IsNullOrWhiteSpace(id) ? null : id.Trim();
 	}
 
 	private static Uri AppendOrReplaceQuery(Uri uri, string key, string value)
@@ -493,10 +592,37 @@ public sealed class EmbyPlaybackProvider(
 		int tmdbId,
 		CancellationToken cancellationToken)
 	{
+		static bool HasRequestedTmdbId(ItemDto item, int requestedTmdbId)
+		{
+			if (item.ProviderIds is null || item.ProviderIds.Count == 0)
+			{
+				return false;
+			}
+
+			var expected = requestedTmdbId.ToString(CultureInfo.InvariantCulture);
+			foreach (var kvp in item.ProviderIds)
+			{
+				var key = (kvp.Key ?? string.Empty).Trim();
+				if (!key.Contains("tmdb", StringComparison.OrdinalIgnoreCase))
+				{
+					continue;
+				}
+
+				var value = (kvp.Value ?? string.Empty).Trim();
+				if (string.Equals(value, expected, StringComparison.OrdinalIgnoreCase)
+					|| string.Equals(value, $"tmdb.{expected}", StringComparison.OrdinalIgnoreCase))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
 		var candidates = new[]
 		{
-			$"Users/{Uri.EscapeDataString(userId)}/Items?IncludeItemTypes=Movie&Recursive=true&Limit=1&Fields=ProviderIds&AnyProviderIdEquals=tmdb.{tmdbId}",
-			$"Users/{Uri.EscapeDataString(userId)}/Items?IncludeItemTypes=Movie&Recursive=true&Limit=1&Fields=ProviderIds&AnyProviderIdEquals=Tmdb.{tmdbId}",
+			$"Users/{Uri.EscapeDataString(userId)}/Items?IncludeItemTypes=Movie&Recursive=true&Limit=10&Fields=ProviderIds&AnyProviderIdEquals=tmdb.{tmdbId}",
+			$"Users/{Uri.EscapeDataString(userId)}/Items?IncludeItemTypes=Movie&Recursive=true&Limit=10&Fields=ProviderIds&AnyProviderIdEquals=Tmdb.{tmdbId}",
 		};
 
 		foreach (var query in candidates)
@@ -513,9 +639,44 @@ public sealed class EmbyPlaybackProvider(
 
 			var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 			var dto = JsonSerializer.Deserialize<ItemsResponseDto>(json, Json);
-			var id = dto?.Items?.FirstOrDefault()?.Id;
+			var match = dto?.Items?.FirstOrDefault(i => i is not null && HasRequestedTmdbId(i, tmdbId));
+			var id = match?.Id;
 			if (!string.IsNullOrWhiteSpace(id))
 			{
+				return id.Trim();
+			}
+		}
+
+		// Fallback: page through the user's movie library and locate an item whose ProviderIds contains the TMDB id.
+		// This avoids incorrectly returning the library's first movie if server-side filtering is unavailable.
+		const int pageSize = 200;
+		const int maxToScan = 5000;
+		for (var startIndex = 0; startIndex < maxToScan; startIndex += pageSize)
+		{
+			var query = $"Users/{Uri.EscapeDataString(userId)}/Items?IncludeItemTypes=Movie&Recursive=true&Fields=ProviderIds&StartIndex={startIndex}&Limit={pageSize}";
+			var uri = new Uri($"{baseUrl}{query}", UriKind.Absolute);
+			using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+			request.Headers.Accept.ParseAdd("application/json");
+			request.Headers.Add("X-Emby-Token", apiKey);
+
+			using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+			if (!response.IsSuccessStatusCode)
+			{
+				break;
+			}
+
+			var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+			var dto = JsonSerializer.Deserialize<ItemsResponseDto>(json, Json);
+			if (dto?.Items is not { Count: > 0 })
+			{
+				break;
+			}
+
+			var match = dto.Items.FirstOrDefault(i => i is not null && HasRequestedTmdbId(i, tmdbId));
+			var id = match?.Id;
+			if (!string.IsNullOrWhiteSpace(id))
+			{
+				logger.LogDebug("emby item id lookup: found TMDB match via fallback scan. TmdbId={TmdbId} StartIndex={StartIndex}", tmdbId, startIndex);
 				return id.Trim();
 			}
 		}
@@ -556,7 +717,16 @@ public sealed class EmbyPlaybackProvider(
 		[property: JsonPropertyName("Items")] List<ItemDto>? Items,
 		[property: JsonPropertyName("TotalRecordCount")] int TotalRecordCount);
 
-	private sealed record ItemDto([property: JsonPropertyName("Id")] string? Id);
+	private sealed record ItemDto(
+		[property: JsonPropertyName("Id")] string? Id,
+		[property: JsonPropertyName("ProviderIds")] Dictionary<string, string>? ProviderIds);
+
+	private sealed record PlaybackInfoResponseDto(
+		[property: JsonPropertyName("MediaSources")] List<MediaSourceInfoDto>? MediaSources,
+		[property: JsonPropertyName("PlaySessionId")] string? PlaySessionId,
+		[property: JsonPropertyName("ErrorCode")] string? ErrorCode);
+
+	private sealed record MediaSourceInfoDto([property: JsonPropertyName("Id")] string? Id);
 
 	private sealed record ItemDetailsDto([property: JsonPropertyName("MediaStreams")] List<MediaStreamDto>? MediaStreams);
 

--- a/src/Tindarr.Infrastructure/Playback/Providers/JellyfinPlaybackProvider.cs
+++ b/src/Tindarr.Infrastructure/Playback/Providers/JellyfinPlaybackProvider.cs
@@ -1,6 +1,7 @@
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Tindarr.Application.Abstractions.Persistence;
 using Tindarr.Application.Interfaces.Playback;
@@ -12,7 +13,7 @@ public sealed class JellyfinPlaybackProvider(
 	IServiceSettingsRepository settingsRepo,
 	ICastingSettingsRepository castingSettingsRepo,
 	HttpClient httpClient,
-	ILogger<JellyfinPlaybackProvider> logger) : IDirectPlaybackProvider
+	ILogger<JellyfinPlaybackProvider> logger) : IDirectPlaybackProvider, ICastPlaybackProvider
 {
 	private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
 
@@ -20,16 +21,91 @@ public sealed class JellyfinPlaybackProvider(
 
 	public async Task<Uri?> TryBuildDirectMovieStreamUrlAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
 	{
-		var upstream = await BuildMovieStreamRequestAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+		// Direct URLs are only used for cast devices; prefer a cast-compatible request.
+		var upstream = await BuildMovieCastStreamRequestAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
 		if (!upstream.Headers.TryGetValue("X-Emby-Token", out var token) || string.IsNullOrWhiteSpace(token))
 		{
 			return null;
 		}
 
-		return AppendOrReplaceQuery(upstream.Uri, "api_key", token);
+		// Cast devices can't send headers; include token in query.
+		// Jellyfin/Emby commonly accept either api_key or X-Emby-Token as query param.
+		var uri = AppendOrReplaceQuery(upstream.Uri, "api_key", token);
+		uri = AppendOrReplaceQuery(uri, "X-Emby-Token", token);
+		return uri;
 	}
 
 	public async Task<UpstreamPlaybackRequest> BuildMovieStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
+	{
+		var (baseUrl, apiKey, _userId, itemId, streamSelection) = await ResolveContextAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+
+		var queryParts = new List<string>(capacity: 10)
+		{
+			$"api_key={Uri.EscapeDataString(apiKey)}",
+			"static=true"
+		};
+		if (streamSelection.AudioStreamIndex is not null)
+		{
+			queryParts.Add($"audioStreamIndex={streamSelection.AudioStreamIndex.Value}");
+		}
+		if (streamSelection.SubtitleStreamIndex is not null)
+		{
+			queryParts.Add($"subtitleStreamIndex={streamSelection.SubtitleStreamIndex.Value}");
+		}
+		if (!string.IsNullOrWhiteSpace(streamSelection.SubtitleMethod))
+		{
+			queryParts.Add($"subtitleMethod={Uri.EscapeDataString(streamSelection.SubtitleMethod!)}");
+		}
+
+		var upstreamUri = new Uri($"{baseUrl}Videos/{Uri.EscapeDataString(itemId)}/stream?{string.Join("&", queryParts)}", UriKind.Absolute);
+		return new UpstreamPlaybackRequest(
+			Uri: upstreamUri,
+			Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+			{
+				["X-Emby-Token"] = apiKey
+			});
+	}
+
+	public async Task<UpstreamPlaybackRequest> BuildMovieCastStreamRequestAsync(ServiceScope scope, int tmdbId, CancellationToken cancellationToken)
+	{
+		var (baseUrl, apiKey, _userId, itemId, streamSelection) = await ResolveContextAsync(scope, tmdbId, cancellationToken).ConfigureAwait(false);
+
+		// Chromecast audio decoding is more limited than Jellyfin's normal web clients.
+		// Force an mp4 container + AAC audio, and cap channels to stereo as a safe default.
+		var queryParts = new List<string>(capacity: 16)
+		{
+			$"api_key={Uri.EscapeDataString(apiKey)}",
+			"static=false",
+			"audioCodec=aac",
+			"maxAudioChannels=2",
+			"transcodingMaxAudioChannels=2"
+		};
+		if (streamSelection.AudioStreamIndex is not null)
+		{
+			queryParts.Add($"audioStreamIndex={streamSelection.AudioStreamIndex.Value}");
+		}
+		// IMPORTANT: MP4 cannot mux common text subtitle codecs (e.g. SRT/subrip).
+		// Only request subtitles when we are burning them into video (Encode).
+		if (streamSelection.SubtitleStreamIndex is not null
+			&& string.Equals(streamSelection.SubtitleMethod, "Encode", StringComparison.OrdinalIgnoreCase))
+		{
+			queryParts.Add($"subtitleStreamIndex={streamSelection.SubtitleStreamIndex.Value}");
+			queryParts.Add("subtitleMethod=Encode");
+		}
+
+		var upstreamUri = new Uri($"{baseUrl}Videos/{Uri.EscapeDataString(itemId)}/stream.mp4?{string.Join("&", queryParts)}", UriKind.Absolute);
+		return new UpstreamPlaybackRequest(
+			Uri: upstreamUri,
+			Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+			{
+				["X-Emby-Token"] = apiKey
+			});
+	}
+
+	private async Task<(string BaseUrl, string ApiKey, string UserId, string ItemId, StreamSelection StreamSelection)> ResolveContextAsync(
+		ServiceScope scope,
+		int tmdbId,
+		CancellationToken cancellationToken)
 	{
 		var settings = await settingsRepo.GetAsync(scope, cancellationToken).ConfigureAwait(false);
 		if (settings is null || string.IsNullOrWhiteSpace(settings.JellyfinBaseUrl) || string.IsNullOrWhiteSpace(settings.JellyfinApiKey))
@@ -55,27 +131,7 @@ public sealed class JellyfinPlaybackProvider(
 		var castingSettings = await castingSettingsRepo.GetAsync(cancellationToken).ConfigureAwait(false);
 		var streamSelection = await TrySelectStreamsAsync(httpClient, baseUrl, apiKey, userId, itemId, castingSettings, cancellationToken).ConfigureAwait(false);
 
-		var queryParts = new List<string>(capacity: 8) { "static=true" };
-		if (streamSelection.AudioStreamIndex is not null)
-		{
-			queryParts.Add($"audioStreamIndex={streamSelection.AudioStreamIndex.Value}");
-		}
-		if (streamSelection.SubtitleStreamIndex is not null)
-		{
-			queryParts.Add($"subtitleStreamIndex={streamSelection.SubtitleStreamIndex.Value}");
-		}
-		if (!string.IsNullOrWhiteSpace(streamSelection.SubtitleMethod))
-		{
-			queryParts.Add($"subtitleMethod={Uri.EscapeDataString(streamSelection.SubtitleMethod!)}");
-		}
-
-		var upstreamUri = new Uri($"{baseUrl}Videos/{Uri.EscapeDataString(itemId)}/stream?{string.Join("&", queryParts)}", UriKind.Absolute);
-		return new UpstreamPlaybackRequest(
-			Uri: upstreamUri,
-			Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-			{
-				["X-Emby-Token"] = apiKey
-			});
+		return (baseUrl, apiKey, userId, itemId, streamSelection);
 	}
 
 	private static Uri AppendOrReplaceQuery(Uri uri, string key, string value)
@@ -498,31 +554,63 @@ public sealed class JellyfinPlaybackProvider(
 		int tmdbId,
 		CancellationToken cancellationToken)
 	{
-		// Jellyfin doesn't have a single stable query shape across all versions/plugins.
-		// Try a few safe variants.
-		var candidates = new[]
+		static bool HasRequestedTmdbId(ItemDto item, int requestedTmdbId)
 		{
-			$"Users/{Uri.EscapeDataString(userId)}/Items?IncludeItemTypes=Movie&Recursive=true&Limit=1&Fields=ProviderIds&AnyProviderIdEquals=tmdb.{tmdbId}",
-			$"Users/{Uri.EscapeDataString(userId)}/Items?IncludeItemTypes=Movie&Recursive=true&Limit=1&Fields=ProviderIds&AnyProviderIdEquals=Tmdb.{tmdbId}",
-		};
+			if (item.ProviderIds is null || item.ProviderIds.Count == 0)
+			{
+				return false;
+			}
 
-		foreach (var query in candidates)
+			var expected = requestedTmdbId.ToString(CultureInfo.InvariantCulture);
+			foreach (var kvp in item.ProviderIds)
+			{
+				var key = (kvp.Key ?? string.Empty).Trim();
+				if (!key.Contains("tmdb", StringComparison.OrdinalIgnoreCase))
+				{
+					continue;
+				}
+
+				var value = (kvp.Value ?? string.Empty).Trim();
+				if (string.Equals(value, expected, StringComparison.OrdinalIgnoreCase)
+					|| string.Equals(value, $"tmdb.{expected}", StringComparison.OrdinalIgnoreCase))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		// Jellyfin: query the library using the documented /Items endpoint and scan for ProviderIds.Tmdb.
+		// This avoids relying on undocumented provider-id query operators that may be unsupported.
+		const int pageSize = 200;
+		const int maxToScan = 5000;
+		for (var startIndex = 0; startIndex < maxToScan; startIndex += pageSize)
 		{
+			var query = $"Items?userId={Uri.EscapeDataString(userId)}&includeItemTypes=Movie&recursive=true&hasTmdbId=true&fields=ProviderIds&startIndex={startIndex}&limit={pageSize}";
 			var uri = new Uri($"{baseUrl}{query}", UriKind.Absolute);
 			using var request = new HttpRequestMessage(HttpMethod.Get, uri);
 			request.Headers.Accept.ParseAdd("application/json");
 			request.Headers.Add("X-Emby-Token", apiKey);
+
 			using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
 			if (!response.IsSuccessStatusCode)
 			{
-				continue;
+				break;
 			}
 
 			var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 			var dto = JsonSerializer.Deserialize<ItemsResponseDto>(json, Json);
-			var id = dto?.Items?.FirstOrDefault()?.Id;
+			if (dto?.Items is not { Count: > 0 })
+			{
+				break;
+			}
+
+			var match = dto.Items.FirstOrDefault(i => i is not null && HasRequestedTmdbId(i, tmdbId));
+			var id = match?.Id;
 			if (!string.IsNullOrWhiteSpace(id))
 			{
+				logger.LogDebug("jellyfin item id lookup: found TMDB match. TmdbId={TmdbId} StartIndex={StartIndex}", tmdbId, startIndex);
 				return id.Trim();
 			}
 		}
@@ -547,7 +635,9 @@ public sealed class JellyfinPlaybackProvider(
 		[property: JsonPropertyName("Items")] List<ItemDto>? Items,
 		[property: JsonPropertyName("TotalRecordCount")] int TotalRecordCount);
 
-	private sealed record ItemDto([property: JsonPropertyName("Id")] string? Id);
+	private sealed record ItemDto(
+		[property: JsonPropertyName("Id")] string? Id,
+		[property: JsonPropertyName("ProviderIds")] Dictionary<string, string>? ProviderIds);
 
 	private sealed record ItemDetailsDto([property: JsonPropertyName("MediaStreams")] List<MediaStreamDto>? MediaStreams);
 

--- a/tests/Tindarr.UnitTests/Api/CastingControllerSessionLifecycleTests.cs
+++ b/tests/Tindarr.UnitTests/Api/CastingControllerSessionLifecycleTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using Tindarr.Api.Controllers;
 using Tindarr.Application.Abstractions.Persistence;
@@ -20,6 +22,35 @@ namespace Tindarr.UnitTests.Api;
 
 public sealed class CastingControllerSessionLifecycleTests
 {
+	[Fact]
+	public void RegisterSession_WhenDeviceRecasts_EndsPreviousSession()
+	{
+		var store = new CastingSessionStore(new MemoryCache(new MemoryCacheOptions()));
+
+		store.RegisterSession(
+			sessionId: "s1",
+			deviceId: "device-1",
+			contentTitle: "Movie 1",
+			contentSubtitle: "Plex",
+			contentType: "video/mp4",
+			contentRuntimeSeconds: 10);
+
+		store.RegisterSession(
+			sessionId: "s2",
+			deviceId: "device-1",
+			contentTitle: "Movie 2",
+			contentSubtitle: "Plex",
+			contentType: "video/mp4",
+			contentRuntimeSeconds: 10);
+
+		var sessions = store.GetActiveSessions();
+		Assert.Single(sessions);
+		Assert.Equal("s2", sessions[0].SessionId);
+
+		var events = store.GetRecentEvents();
+		Assert.Contains(events, e => e.EventType == "session_ended" && e.Message.Contains("ended", StringComparison.OrdinalIgnoreCase));
+	}
+
 	[Fact]
 	public async Task CastMovie_WhenCastAsyncThrows_DoesNotLeaveActiveSession()
 	{
@@ -71,6 +102,90 @@ public sealed class CastingControllerSessionLifecycleTests
 		Assert.Single(sessions);
 		Assert.Equal("device-1", sessions[0].DeviceId);
 		Assert.Equal("active", sessions[0].SessionState);
+	}
+
+	[Fact]
+	public async Task GetMovieCastUrl_WhenDirectUrlAvailable_RegistersActiveSession()
+	{
+		var store = new CastingSessionStore(new MemoryCache(new MemoryCacheOptions()));
+		var castClient = new TestCastClient(throwOnCast: false);
+		var directProvider = new TestDirectPlaybackProvider(
+			ServiceType.Plex,
+			directUri: new Uri("http://10.0.0.2/movie.mp4"));
+
+		var controller = CreateController(castClient, store, playbackProviders: [directProvider]);
+
+		var request = new GetMovieCastUrlRequest(
+			ServiceType: "Plex",
+			ServerId: "server-1",
+			TmdbId: 123,
+			Title: "Test Movie",
+			DeviceId: "Living Room TV");
+
+		var result = await controller.GetMovieCastUrl(request, CancellationToken.None);
+		var ok = Assert.IsType<Microsoft.AspNetCore.Mvc.OkObjectResult>(result.Result);
+		var dto = Assert.IsType<CastMediaUrlDto>(ok.Value);
+		Assert.False(string.IsNullOrWhiteSpace(dto.SessionId));
+
+		var sessions = store.GetActiveSessions();
+		Assert.Single(sessions);
+		Assert.Equal("Living Room TV", sessions[0].DeviceId);
+		Assert.Equal("Test Movie", sessions[0].ContentTitle);
+	}
+
+	[Fact]
+	public void EndCastingSession_WhenSessionExists_RemovesFromActiveSessions()
+	{
+		var store = new CastingSessionStore(new MemoryCache(new MemoryCacheOptions()));
+		var controller = CreateController(new TestCastClient(throwOnCast: false), store, playbackProviders: []);
+
+		store.RegisterSession(
+			sessionId: "s1",
+			deviceId: "Living Room TV",
+			contentTitle: "Test Movie",
+			contentSubtitle: "Plex",
+			contentType: "video/mp4",
+			contentRuntimeSeconds: 10);
+
+		var result = controller.EndCastingSession("s1");
+		Assert.IsType<Microsoft.AspNetCore.Mvc.OkResult>(result);
+		Assert.Empty(store.GetActiveSessions());
+	}
+
+	[Fact]
+	public async Task GetRoomQrCastUrl_WhenRoomExists_RegistersActiveSession()
+	{
+		var store = new CastingSessionStore(new MemoryCache(new MemoryCacheOptions()));
+		var controller = new CastingController(
+			castClient: new TestCastClient(throwOnCast: false),
+			castUrlTokenService: new TestCastUrlTokenService(),
+			playbackTokenService: new TestPlaybackTokenService(),
+			playbackProviders: [],
+			roomService: new TestRoomService(roomId: "room-1"),
+			baseUrlResolver: new TestBaseUrlResolver(),
+			joinAddressSettings: new TestJoinAddressSettingsRepository(),
+			baseUrlOptions: Options.Create(new BaseUrlOptions { Lan = "http://10.0.0.1:5000" }),
+			logger: NullLogger<CastingController>.Instance,
+			castingSessionStore: store);
+
+		controller.ControllerContext = new Microsoft.AspNetCore.Mvc.ControllerContext
+		{
+			HttpContext = new DefaultHttpContext()
+		};
+		controller.ControllerContext.HttpContext.Request.Scheme = "http";
+		controller.ControllerContext.HttpContext.Request.Host = new HostString("10.0.0.1", 5000);
+		controller.ControllerContext.HttpContext.RequestServices = new ServiceCollection().BuildServiceProvider();
+
+		var result = await controller.GetRoomQrCastUrl("room-1", CancellationToken.None);
+		var ok = Assert.IsType<Microsoft.AspNetCore.Mvc.OkObjectResult>(result.Result);
+		var dto = Assert.IsType<CastMediaUrlDto>(ok.Value);
+		Assert.False(string.IsNullOrWhiteSpace(dto.SessionId));
+
+		var sessions = store.GetActiveSessions();
+		Assert.Single(sessions);
+		Assert.Equal("Join room", sessions[0].ContentTitle);
+		Assert.Equal("room-1", sessions[0].ContentSubtitle);
+		Assert.Equal("image/png", sessions[0].ContentType);
 	}
 
 	private static CastingController CreateController(
@@ -132,7 +247,7 @@ public sealed class CastingControllerSessionLifecycleTests
 		public bool TryValidateMovieToken(string token, ServiceScope scope, int tmdbId, DateTimeOffset nowUtc) => true;
 	}
 
-	private sealed class TestRoomService : IRoomService
+	private sealed class TestRoomService(string? roomId = null) : IRoomService
 	{
 		public Task<RoomState> CreateAsync(string ownerUserId, ServiceScope scope, CancellationToken cancellationToken)
 			=> throw new NotImplementedException();
@@ -143,8 +258,26 @@ public sealed class CastingControllerSessionLifecycleTests
 		public Task<RoomState> CloseAsync(string roomId, string ownerUserId, CancellationToken cancellationToken)
 			=> throw new NotImplementedException();
 
-		public Task<RoomState?> GetAsync(string roomId, CancellationToken cancellationToken)
-			=> throw new NotImplementedException();
+		public Task<RoomState?> GetAsync(string requestedRoomId, CancellationToken cancellationToken)
+		{
+			if (string.IsNullOrWhiteSpace(roomId))
+			{
+				throw new NotImplementedException();
+			}
+			if (!string.Equals(requestedRoomId, roomId, StringComparison.Ordinal))
+			{
+				return Task.FromResult<RoomState?>(null);
+			}
+			var now = DateTimeOffset.UtcNow;
+			return Task.FromResult<RoomState?>(new RoomState(
+				RoomId: roomId,
+				OwnerUserId: "owner",
+				Scope: new ServiceScope(ServiceType.Plex, "server-1"),
+				IsClosed: false,
+				CreatedAtUtc: now,
+				LastActivityAtUtc: now,
+				Members: []));
+		}
 
 		public Task<IReadOnlyList<SwipeCard>> GetSwipeDeckAsync(string roomId, string userId, int limit, CancellationToken cancellationToken)
 			=> throw new NotImplementedException();

--- a/tests/Tindarr.UnitTests/Infrastructure/Playback/EmbyPlaybackProviderCastUrlTests.cs
+++ b/tests/Tindarr.UnitTests/Infrastructure/Playback/EmbyPlaybackProviderCastUrlTests.cs
@@ -1,0 +1,210 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Tindarr.Application.Abstractions.Persistence;
+using Tindarr.Application.Interfaces.Playback;
+using Tindarr.Domain.Common;
+using Tindarr.Infrastructure.Playback.Providers;
+using Xunit;
+
+namespace Tindarr.UnitTests.Infrastructure.Playback;
+
+public sealed class EmbyPlaybackProviderCastUrlTests
+{
+	[Fact]
+	public async Task BuildMovieCastStreamRequestAsync_includes_DeviceId_and_MediaSourceId()
+	{
+		// Arrange
+		var tmdbId = 123;
+		var scope = new ServiceScope(ServiceType.Emby, "emby-main");
+
+		var settingsRepo = new FakeServiceSettingsRepository(CreateServiceSettingsRecord(
+			serviceType: ServiceType.Emby,
+			serverId: "emby-main",
+			embyBaseUrl: "http://emby.local:8096",
+			embyApiKey: "api-key"));
+		var castingSettingsRepo = new FakeCastingSettingsRepository(null);
+		var httpClient = new HttpClient(new FakeEmbyHandler(tmdbId));
+
+		var provider = new EmbyPlaybackProvider(
+			settingsRepo,
+			castingSettingsRepo,
+			httpClient,
+			NullLogger<EmbyPlaybackProvider>.Instance);
+
+		// Act
+		var request = await provider.BuildMovieCastStreamRequestAsync(scope, tmdbId, CancellationToken.None);
+		var url = request.Uri.ToString();
+
+		// Assert
+		Assert.Contains("/emby/Videos/", url, StringComparison.OrdinalIgnoreCase);
+		Assert.Contains("/stream.mp4?", url, StringComparison.OrdinalIgnoreCase);
+		Assert.Contains("DeviceId=tindarr-cast%3Aemby-main", url, StringComparison.Ordinal);
+		Assert.Contains("MediaSourceId=ms-1", url, StringComparison.Ordinal);
+		Assert.Contains("Static=false", url, StringComparison.Ordinal);
+		Assert.Contains("AudioCodec=aac", url, StringComparison.Ordinal);
+		Assert.Contains("VideoCodec=h264", url, StringComparison.Ordinal);
+		Assert.Contains("MaxWidth=1920", url, StringComparison.Ordinal);
+		Assert.Contains("MaxHeight=1080", url, StringComparison.Ordinal);
+		Assert.Contains("VideoBitRate=8000000", url, StringComparison.Ordinal);
+	}
+
+	private sealed class FakeEmbyHandler : HttpMessageHandler
+	{
+		private readonly int _tmdbId;
+
+		public FakeEmbyHandler(int tmdbId)
+		{
+			_tmdbId = tmdbId;
+		}
+
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			var pathAndQuery = request.RequestUri?.PathAndQuery ?? string.Empty;
+
+			if (pathAndQuery.Contains("/emby/Users", StringComparison.OrdinalIgnoreCase)
+				&& request.Method == HttpMethod.Get
+				&& !pathAndQuery.Contains("/emby/Users/", StringComparison.OrdinalIgnoreCase))
+			{
+				return Task.FromResult(Json(new[]
+				{
+					new { Id = "user-1", Policy = new { IsAdministrator = true } }
+				}));
+			}
+
+			if (pathAndQuery.Contains("/emby/Users/user-1/Items", StringComparison.OrdinalIgnoreCase)
+				&& request.Method == HttpMethod.Get
+				&& !pathAndQuery.Contains("/emby/Users/user-1/Items/item-1", StringComparison.OrdinalIgnoreCase))
+			{
+				return Task.FromResult(Json(new
+				{
+					Items = new[]
+					{
+						new
+						{
+							Id = "item-1",
+							ProviderIds = new Dictionary<string, string> { ["Tmdb"] = _tmdbId.ToString() }
+						}
+					}
+				}));
+			}
+
+			if (pathAndQuery.Contains("/emby/Users/user-1/Items/item-1", StringComparison.OrdinalIgnoreCase)
+				&& request.Method == HttpMethod.Get)
+			{
+				return Task.FromResult(Json(new
+				{
+					MediaStreams = Array.Empty<object>()
+				}));
+			}
+
+			if (pathAndQuery.Contains("/emby/Items/item-1/PlaybackInfo", StringComparison.OrdinalIgnoreCase)
+				&& request.Method == HttpMethod.Get)
+			{
+				return Task.FromResult(Json(new
+				{
+					MediaSources = new[]
+					{
+						new { Id = "ms-1" }
+					},
+					PlaySessionId = "ps-1"
+				}));
+			}
+
+			return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+			{
+				Content = new StringContent($"No route matched: {request.Method} {pathAndQuery}")
+			});
+		}
+
+		private static HttpResponseMessage Json(object payload)
+		{
+			var json = JsonSerializer.Serialize(payload);
+			return new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new StringContent(json, Encoding.UTF8, "application/json")
+			};
+		}
+	}
+
+	private static ServiceSettingsRecord CreateServiceSettingsRecord(
+		ServiceType serviceType,
+		string serverId,
+		string? embyBaseUrl = null,
+		string? embyApiKey = null)
+	{
+		return new ServiceSettingsRecord(
+			ServiceType: serviceType,
+			ServerId: serverId,
+			RadarrBaseUrl: "",
+			RadarrApiKey: "",
+			RadarrQualityProfileId: null,
+			RadarrRootFolderPath: null,
+			RadarrTagLabel: null,
+			RadarrTagId: null,
+			RadarrAutoAddEnabled: false,
+			RadarrAutoAddIntervalMinutes: null,
+			RadarrLastAutoAddRunUtc: null,
+			RadarrLastAutoAddAcceptedId: null,
+			RadarrLastLibrarySyncUtc: null,
+			MatchMinUsers: null,
+			MatchMinUserPercent: null,
+			JellyfinBaseUrl: null,
+			JellyfinApiKey: null,
+			JellyfinServerName: null,
+			JellyfinServerVersion: null,
+			JellyfinLastLibrarySyncUtc: null,
+			EmbyBaseUrl: embyBaseUrl,
+			EmbyApiKey: embyApiKey,
+			EmbyServerName: null,
+			EmbyServerVersion: null,
+			EmbyLastLibrarySyncUtc: null,
+			PlexClientIdentifier: null,
+			PlexAuthToken: null,
+			PlexServerName: null,
+			PlexServerUri: null,
+			PlexServerVersion: null,
+			PlexServerPlatform: null,
+			PlexServerOwned: null,
+			PlexServerOnline: null,
+			PlexServerAccessToken: null,
+			PlexLastLibrarySyncUtc: null,
+			UpdatedAtUtc: DateTimeOffset.UtcNow);
+	}
+
+	private sealed class FakeServiceSettingsRepository(ServiceSettingsRecord record) : IServiceSettingsRepository
+	{
+		public Task<ServiceSettingsRecord?> GetAsync(ServiceScope scope, CancellationToken cancellationToken)
+		{
+			if (scope.ServiceType != record.ServiceType)
+			{
+				return Task.FromResult<ServiceSettingsRecord?>(null);
+			}
+
+			if (!string.Equals(scope.ServerId, record.ServerId, StringComparison.OrdinalIgnoreCase))
+			{
+				return Task.FromResult<ServiceSettingsRecord?>(null);
+			}
+
+			return Task.FromResult<ServiceSettingsRecord?>(record);
+		}
+
+		public Task<IReadOnlyList<ServiceSettingsRecord>> ListAsync(ServiceType serviceType, CancellationToken cancellationToken) =>
+			throw new NotSupportedException();
+
+		public Task UpsertAsync(ServiceScope scope, ServiceSettingsUpsert upsert, CancellationToken cancellationToken) =>
+			throw new NotSupportedException();
+
+		public Task<bool> DeleteAsync(ServiceScope scope, CancellationToken cancellationToken) =>
+			throw new NotSupportedException();
+	}
+
+	private sealed class FakeCastingSettingsRepository(CastingSettingsRecord? record) : ICastingSettingsRepository
+	{
+		public Task<CastingSettingsRecord?> GetAsync(CancellationToken cancellationToken) => Task.FromResult(record);
+
+		public Task<CastingSettingsRecord> UpsertAsync(CastingSettingsUpsert upsert, CancellationToken cancellationToken) =>
+			throw new NotSupportedException();
+	}
+}

--- a/tests/Tindarr.UnitTests/Infrastructure/Playback/PlexPlaybackProviderStreamSelectionTests.cs
+++ b/tests/Tindarr.UnitTests/Infrastructure/Playback/PlexPlaybackProviderStreamSelectionTests.cs
@@ -310,5 +310,8 @@ public sealed class PlexPlaybackProviderStreamSelectionTests
 
 		public Task UpsertAsync(ServiceScope scope, ServiceSettingsUpsert upsert, CancellationToken cancellationToken) =>
 			throw new NotSupportedException();
+
+		public Task<bool> DeleteAsync(ServiceScope scope, CancellationToken cancellationToken) =>
+			throw new NotSupportedException();
 	}
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,7 +14,8 @@ import TmdbBulkJobToast from "./components/TmdbBulkJobToast";
 import PlexBulkJobToast from "./components/PlexBulkJobToast";
 import { adminFetchUpdateCheck, fetchConfiguredScopes, fetchInfo } from "./api/client";
 import type { AdminUpdateCheckResponse, InfoResponse, ServiceScopeOptionDto } from "./api/contracts";
-import { getServiceScope, SERVICE_SCOPE_UPDATED_EVENT, setServiceScopeAndNotify, type ServiceScope } from "./serviceScope";
+import { getServiceScope, SERVICE_SCOPE_UPDATED_EVENT, setServiceScopeAndNotify, DEFAULT_SERVICE_SCOPE, type ServiceScope } from "./serviceScope";
+import { CONFIGURED_SCOPES_UPDATED_EVENT } from "./configuredScopes";
 
 const HEADER_COLLAPSED_KEY = "tindarr:headerCollapsed:v1";
 
@@ -81,11 +82,43 @@ function AppLayout() {
     }
   });
 
+  const reloadConfiguredScopes = async () => {
+    try {
+      const scopes = await fetchConfiguredScopes();
+      setAvailableScopes(scopes);
+    } catch (err) {
+      console.error("Failed to fetch configured scopes:", err);
+    }
+  };
+
   useEffect(() => {
-    fetchConfiguredScopes()
-      .then(setAvailableScopes)
-      .catch((err) => console.error("Failed to fetch configured scopes:", err));
+    void reloadConfiguredScopes();
   }, []);
+
+  useEffect(() => {
+    function handleScopesUpdated() {
+      void reloadConfiguredScopes();
+    }
+
+    window.addEventListener(CONFIGURED_SCOPES_UPDATED_EVENT, handleScopesUpdated);
+    return () => window.removeEventListener(CONFIGURED_SCOPES_UPDATED_EVENT, handleScopesUpdated);
+  }, []);
+
+  useEffect(() => {
+    // If the current scope is no longer configured (e.g. server deleted), reset to TMDB.
+    // This avoids showing a stale/empty scope option in the header picker.
+    if (availableScopes.length === 0) return;
+
+    const exists = availableScopes.some(
+      (s) =>
+        s.serviceType.toLowerCase() === currentScope.serviceType.toLowerCase() &&
+        s.serverId.toLowerCase() === currentScope.serverId.toLowerCase()
+    );
+
+    if (!exists) {
+      setServiceScopeAndNotify(DEFAULT_SERVICE_SCOPE);
+    }
+  }, [availableScopes, currentScope.serviceType, currentScope.serverId]);
 
   useEffect(() => {
     fetchInfo()

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -366,6 +366,13 @@ export async function getRoomQrCastUrl(roomId: string): Promise<CastMediaUrlDto>
   });
 }
 
+export async function endCastingSession(sessionId: string): Promise<void> {
+  await apiRequest<void>({
+    path: `/api/v1/casting/sessions/${encodeURIComponent(sessionId)}/end`,
+    method: "POST"
+  });
+}
+
 export async function castMovie(request: CastMovieRequest): Promise<void> {
   await apiRequest<void>({
     path: "/api/v1/casting/movie",
@@ -611,6 +618,13 @@ export async function plexSyncServers(): Promise<PlexServerDto[]> {
   });
 }
 
+export async function plexDeleteServer(serverId: string): Promise<void> {
+  await apiRequest<void>({
+    path: `/api/v1/plex/servers/${encodeURIComponent(serverId)}`,
+    method: "DELETE"
+  });
+}
+
 export async function plexSyncLibrary(serviceType: string, serverId: string) {
   return apiRequest<{ serviceType: string; serverId: string; count: number; syncedAtUtc: string }>({
     path: "/api/v1/plex/library/sync",
@@ -720,6 +734,13 @@ export async function jellyfinListServers(): Promise<JellyfinServerDto[]> {
   });
 }
 
+export async function jellyfinDeleteServer(serverId: string): Promise<void> {
+  await apiRequest<void>({
+    path: `/api/v1/jellyfin/servers/${encodeURIComponent(serverId)}`,
+    method: "DELETE"
+  });
+}
+
 export async function jellyfinGetSettings(serviceType: string, serverId: string): Promise<JellyfinSettingsDto> {
   return apiRequest<JellyfinSettingsDto>({
     path: "/api/v1/jellyfin/settings",
@@ -758,6 +779,13 @@ export async function jellyfinSyncLibrary(serviceType: string, serverId: string)
 export async function embyListServers(): Promise<EmbyServerDto[]> {
   return apiRequest<EmbyServerDto[]>({
     path: "/api/v1/emby/servers"
+  });
+}
+
+export async function embyDeleteServer(serverId: string): Promise<void> {
+  await apiRequest<void>({
+    path: `/api/v1/emby/servers/${encodeURIComponent(serverId)}`,
+    method: "DELETE"
   });
 }
 

--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -268,6 +268,7 @@ export type CastMediaUrlDto = {
   contentType: string;
   title: string;
   subTitle: string | null;
+  sessionId?: string | null;
 };
 
 export type GetMovieCastUrlRequest = {
@@ -275,6 +276,7 @@ export type GetMovieCastUrlRequest = {
   serverId: string;
   tmdbId: number;
   title?: string | null;
+  deviceId?: string | null;
 };
 
 export type MovieDetailsDto = {

--- a/ui/src/api/sse.ts
+++ b/ui/src/api/sse.ts
@@ -1,0 +1,138 @@
+import { getAccessToken } from "../auth/session";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
+
+type QueryValue = string | number | boolean | null | undefined;
+
+function buildUrl(path: string, query?: Record<string, QueryValue>) {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const url = new URL(`${API_BASE_URL}${normalizedPath}`, window.location.origin);
+
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value === null || value === undefined) continue;
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return url.toString();
+}
+
+export type SseMessage = {
+  event?: string;
+  data: string;
+};
+
+export type ConnectSseOptions = {
+  path: string;
+  query?: Record<string, QueryValue>;
+  signal: AbortSignal;
+  onMessage: (msg: SseMessage) => void;
+};
+
+function readErrorMessage(text: string | null | undefined, fallback: string) {
+  const t = (text ?? "").trim();
+  if (t) return t;
+  return fallback;
+}
+
+/**
+ * Opens a Server-Sent Events (SSE) stream over `fetch`.
+ * This is used instead of `EventSource` so we can attach Authorization headers.
+ */
+export async function connectSse(options: ConnectSseOptions): Promise<void> {
+  const headers: Record<string, string> = {
+    Accept: "text/event-stream"
+  };
+
+  const token = getAccessToken();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(buildUrl(options.path, options.query), {
+    method: "GET",
+    headers,
+    cache: "no-store",
+    signal: options.signal
+  });
+
+  if (!response.ok) {
+    let payload: string | null = null;
+    try {
+      payload = await response.text();
+    } catch {
+      payload = null;
+    }
+    throw new Error(readErrorMessage(payload, `SSE request failed (${response.status})`));
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) return;
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  let eventName: string | undefined;
+  let dataLines: string[] = [];
+
+  function dispatchMessage() {
+    if (dataLines.length === 0) {
+      eventName = undefined;
+      return;
+    }
+
+    options.onMessage({
+      event: eventName,
+      data: dataLines.join("\n")
+    });
+
+    eventName = undefined;
+    dataLines = [];
+  }
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+
+    // Parse line-by-line.
+    while (true) {
+      const newlineIndex = buffer.indexOf("\n");
+      if (newlineIndex < 0) break;
+
+      let line = buffer.slice(0, newlineIndex);
+      buffer = buffer.slice(newlineIndex + 1);
+
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+
+      // Blank line ends a message.
+      if (line === "") {
+        dispatchMessage();
+        continue;
+      }
+
+      // Comment line.
+      if (line.startsWith(":")) {
+        continue;
+      }
+
+      if (line.startsWith("event:")) {
+        eventName = line.slice("event:".length).trim();
+        continue;
+      }
+
+      if (line.startsWith("data:")) {
+        // Per SSE spec, data can be sent in multiple lines.
+        dataLines.push(line.slice("data:".length).trimStart());
+        continue;
+      }
+
+      // Ignore other fields (id, retry).
+    }
+  }
+
+  // Flush any trailing message if the stream ends.
+  dispatchMessage();
+}

--- a/ui/src/casting/googleCast.ts
+++ b/ui/src/casting/googleCast.ts
@@ -114,6 +114,54 @@ export function getCurrentCastDevice(): CastDeviceInfo | null {
   return name ? { friendlyName: name } : null;
 }
 
+export function subscribeToCastSessionEnded(onEnded: () => void): () => void {
+  if (!isCastFrameworkReady()) return () => {};
+
+  const castAny = (window as any).cast as any;
+  const context = castAny.framework.CastContext.getInstance();
+  const eventType = castAny.framework.CastContextEventType?.SESSION_STATE_CHANGED ?? "sessionstatechanged";
+
+  const handler = (evt: any) => {
+    const state = String(evt?.sessionState ?? "");
+    const ended = castAny.framework.SessionState?.SESSION_ENDED;
+    if (ended && evt?.sessionState === ended) {
+      onEnded();
+      return;
+    }
+
+    if (state.toUpperCase() === "SESSION_ENDED") {
+      onEnded();
+    }
+  };
+
+  context.addEventListener(eventType, handler);
+  return () => context.removeEventListener(eventType, handler);
+}
+
+export function subscribeToCastMediaFinished(onFinished: () => void): () => void {
+  if (!isCastFrameworkReady()) return () => {};
+
+  const castAny = (window as any).cast as any;
+  const RemotePlayer = castAny.framework?.RemotePlayer;
+  const RemotePlayerController = castAny.framework?.RemotePlayerController;
+  const eventType = castAny.framework?.RemotePlayerEventType?.PLAYER_STATE_CHANGED;
+  if (!RemotePlayer || !RemotePlayerController || !eventType) return () => {};
+
+  const player = new RemotePlayer();
+  const controller = new RemotePlayerController(player);
+
+  const handler = () => {
+    const playerState = String(player?.playerState ?? "").toUpperCase();
+    const idleReason = String(player?.idleReason ?? "").toUpperCase();
+    if (playerState === "IDLE" && idleReason === "FINISHED") {
+      onFinished();
+    }
+  };
+
+  controller.addEventListener(eventType, handler);
+  return () => controller.removeEventListener(eventType, handler);
+}
+
 export async function loadMediaToCastSession(args: { url: string; contentType: string; title: string; subTitle?: string | null }): Promise<void> {
   if (!isCastFrameworkReady()) {
     throw new Error("Cast framework not ready");

--- a/ui/src/components/MovieDetailsModal.tsx
+++ b/ui/src/components/MovieDetailsModal.tsx
@@ -1,9 +1,18 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ApiError } from "../api/http";
-import { castMovie, fetchMovieDetails, getMovieCastUrl, listCastDevices } from "../api/client";
+import { castMovie, endCastingSession, fetchMovieDetails, getMovieCastUrl, listCastDevices } from "../api/client";
 import type { CastDeviceDto, MovieDetailsDto } from "../api/contracts";
 import { getServiceScope, SERVICE_SCOPE_UPDATED_EVENT, type ServiceScope } from "../serviceScope";
-import { ensureGoogleCastSdkLoaded, getCurrentCastDevice, initGoogleCastContext, loadMediaToCastSession, requestCastSession, shouldUseGoogleCastSdk } from "../casting/googleCast";
+import {
+  ensureGoogleCastSdkLoaded,
+  getCurrentCastDevice,
+  initGoogleCastContext,
+  loadMediaToCastSession,
+  requestCastSession,
+  shouldUseGoogleCastSdk,
+  subscribeToCastMediaFinished,
+  subscribeToCastSessionEnded
+} from "../casting/googleCast";
 
 type MovieDetailsModalProps = {
   tmdbId: number;
@@ -23,6 +32,44 @@ export default function MovieDetailsModal({ tmdbId, onClose }: MovieDetailsModal
   const [casting, setCasting] = useState(false);
   const [castMessage, setCastMessage] = useState<string | null>(null);
   const [castUiMode, setCastUiMode] = useState<"sdk" | "fallback">(() => (shouldUseGoogleCastSdk() ? "sdk" : "fallback"));
+
+  const castSessionIdRef = useRef<string | null>(null);
+  const endInFlightRef = useRef(false);
+
+  async function endActiveCastSessionBestEffort(): Promise<void> {
+    const sessionId = castSessionIdRef.current;
+    if (!sessionId) return;
+    if (endInFlightRef.current) return;
+
+    endInFlightRef.current = true;
+    try {
+      await endCastingSession(sessionId);
+    } catch (e) {
+      // best-effort
+      void e;
+    } finally {
+      castSessionIdRef.current = null;
+      endInFlightRef.current = false;
+    }
+  }
+
+  // For SDK casting, end the server-side session when the Cast session ends
+  // or when playback finishes (best-effort; not all receivers report this reliably).
+  useEffect(() => {
+    if (castUiMode !== "sdk") return;
+
+    const unsubEnded = subscribeToCastSessionEnded(() => {
+      void endActiveCastSessionBestEffort();
+    });
+    const unsubFinished = subscribeToCastMediaFinished(() => {
+      void endActiveCastSessionBestEffort();
+    });
+
+    return () => {
+      unsubEnded();
+      unsubFinished();
+    };
+  }, [castUiMode]);
 
   const posterUrl = details?.posterUrl ?? null;
 
@@ -115,9 +162,9 @@ export default function MovieDetailsModal({ tmdbId, onClose }: MovieDetailsModal
 
         initGoogleCastContext();
 
-        const current = getCurrentCastDevice();
+        let current = getCurrentCastDevice();
         if (!current) {
-          await requestCastSession();
+          current = await requestCastSession();
         }
 
         const media = await getMovieCastUrl({
@@ -125,14 +172,22 @@ export default function MovieDetailsModal({ tmdbId, onClose }: MovieDetailsModal
           serverId: currentScope.serverId,
           tmdbId,
           title: details?.title ?? null,
+          deviceId: current.friendlyName,
         });
 
-        await loadMediaToCastSession({
-          url: media.url,
-          contentType: media.contentType,
-          title: media.title,
-          subTitle: media.subTitle,
-        });
+        castSessionIdRef.current = media.sessionId ?? null;
+
+        try {
+          await loadMediaToCastSession({
+            url: media.url,
+            contentType: media.contentType,
+            title: media.title,
+            subTitle: media.subTitle,
+          });
+        } catch (e) {
+          await endActiveCastSessionBestEffort();
+          throw e;
+        }
 
         setCastMessage("Casting…");
         return;

--- a/ui/src/configuredScopes.ts
+++ b/ui/src/configuredScopes.ts
@@ -1,0 +1,5 @@
+export const CONFIGURED_SCOPES_UPDATED_EVENT = "tindarr:configuredScopesUpdated";
+
+export function notifyConfiguredScopesUpdated(): void {
+  window.dispatchEvent(new Event(CONFIGURED_SCOPES_UPDATED_EVENT));
+}

--- a/ui/src/pages/AdminConsolePage.tsx
+++ b/ui/src/pages/AdminConsolePage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ApiError } from "../api/http";
+import { connectSse } from "../api/sse";
+import { notifyConfiguredScopesUpdated } from "../configuredScopes";
 import {
   adminDbListMovies,
   adminCreateUser,
@@ -14,17 +16,19 @@ import {
   adminUpdateJoinAddressSettings,
   adminUpdateMatchSettings,
   adminUpdateUser,
+  embyDeleteServer,
   embyListServers,
   embySyncLibrary,
   embyTestConnection,
   embyUpsertSettings,
+  jellyfinDeleteServer,
   jellyfinListServers,
   jellyfinSyncLibrary,
   jellyfinTestConnection,
   jellyfinUpsertSettings,
   plexCreatePin,
+  plexDeleteServer,
   plexGetAuthStatus,
-  plexGetLibrarySyncStatus,
   plexListLibraryCacheMovies,
   plexListServers,
   plexStartLibrarySync,
@@ -45,8 +49,7 @@ import {
   tmdbListStoredMovies,
   tmdbFillMovieDetails,
   tmdbFetchMovieImages,
-  tmdbStartBuild,
-  adminGetCastingDiagnostics
+  tmdbStartBuild
 } from "../api/client";
 import type {
   CastingDiagnosticsDto,
@@ -360,30 +363,45 @@ function CastingTab() {
   const [diagError, setDiagError] = useState<string | null>(null);
   const [diagLoading, setDiagLoading] = useState(false);
 
-  // Poll diagnostics every 5s
+  // Stream diagnostics (SSE) instead of polling.
   useEffect(() => {
-    let stop = false;
-    let timeoutId: number | null = null;
-    async function poll() {
-      setDiagLoading(true);
-      try {
-        const d = await adminGetCastingDiagnostics();
-        if (!stop) {
-          setDiagnostics(d);
-          setDiagError(null);
+    const abort = new AbortController();
+
+    void (async () => {
+      while (!abort.signal.aborted) {
+        let gotFirst = false;
+        setDiagLoading(true);
+        try {
+          await connectSse({
+            path: "/api/v1/admin/casting/diagnostics/stream",
+            signal: abort.signal,
+            onMessage: (msg) => {
+              if (msg.event && msg.event !== "diagnostics") return;
+              try {
+                const parsed = JSON.parse(msg.data) as CastingDiagnosticsDto;
+                setDiagnostics(parsed);
+                setDiagError(null);
+                gotFirst = true;
+              } catch {
+                // ignore malformed message
+              } finally {
+                setDiagLoading(false);
+              }
+            }
+          });
+        } catch {
+          if (!abort.signal.aborted) setDiagError("Failed to load diagnostics");
+        } finally {
+          if (!abort.signal.aborted && !gotFirst) setDiagLoading(false);
         }
-      } catch (e) {
-        if (!stop) setDiagError("Failed to load diagnostics");
-      } finally {
-        if (!stop) setDiagLoading(false);
+
+        if (abort.signal.aborted) break;
+        // Best-effort reconnect.
+        await new Promise((resolve) => window.setTimeout(resolve, 5000));
       }
-      if (!stop) timeoutId = window.setTimeout(poll, 5000);
-    }
-    poll();
-    return () => {
-      stop = true;
-      if (timeoutId !== null) window.clearTimeout(timeoutId);
-    };
+    })();
+
+    return () => abort.abort();
   }, []);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -1814,7 +1832,7 @@ function PlexTab() {
   const [pin, setPin] = useState<{ pinId: number; code: string; expiresAtUtc: string; authUrl: string } | null>(null);
   const [servers, setServers] = useState<PlexServerDto[]>([]);
   const [syncStatus, setSyncStatus] = useState<PlexLibrarySyncStatusDto | null>(null);
-  const syncPollRef = useRef<number | null>(null);
+  const syncStreamAbortRef = useRef<AbortController | null>(null);
   const [tmdbCacheSettings, setTmdbCacheSettings] = useState<TmdbCacheSettingsDto | null>(null);
 
   const [cacheServerId, setCacheServerId] = useState<string>("default");
@@ -1838,7 +1856,11 @@ function PlexTab() {
       setAuthStatus(status);
       setServers(list);
       if (list.length > 0) {
-        setCacheServerId((prev) => (prev && prev !== "default" ? prev : list[0].serverId));
+			setCacheServerId((prev) =>
+				prev && prev !== "default" && list.some((s) => s.serverId === prev) ? prev : list[0].serverId
+			);
+		} else {
+			setCacheServerId("default");
       }
 
 			// Best-effort: LocalProxy affects whether image fetching is enabled.
@@ -1926,37 +1948,50 @@ function PlexTab() {
     const serverId = syncStatus?.serverId ?? "default";
 
     if (!isRunning) {
-      if (syncPollRef.current) {
-        window.clearInterval(syncPollRef.current);
-        syncPollRef.current = null;
-      }
+      syncStreamAbortRef.current?.abort();
+      syncStreamAbortRef.current = null;
       return;
     }
 
-    if (syncPollRef.current) return;
+    if (syncStreamAbortRef.current) return;
 
-    syncPollRef.current = window.setInterval(() => {
-      void (async () => {
-        try {
-          const next = await plexGetLibrarySyncStatus(serviceType, serverId);
-          setSyncStatus(next);
-          if (next.state !== "running") {
-            if (syncPollRef.current) {
-              window.clearInterval(syncPollRef.current);
-              syncPollRef.current = null;
+    const abort = new AbortController();
+    syncStreamAbortRef.current = abort;
+
+    void (async () => {
+      try {
+        await connectSse({
+          path: "/api/v1/plex/library/sync/status/stream",
+          query: { serviceType, serverId },
+          signal: abort.signal,
+          onMessage: (msg) => {
+            if (msg.event && msg.event !== "status") return;
+            try {
+              const next = JSON.parse(msg.data) as PlexLibrarySyncStatusDto;
+              setSyncStatus(next);
+              if (next.state !== "running") {
+                abort.abort();
+                syncStreamAbortRef.current = null;
+                void load();
+              }
+            } catch {
+              // ignore malformed message
             }
-            await load();
           }
-        } catch {
-          // best-effort polling
+        });
+      } catch {
+        // best-effort streaming; UI can still recover on next explicit load
+      } finally {
+        if (syncStreamAbortRef.current === abort) {
+          syncStreamAbortRef.current = null;
         }
-      })();
-    }, 1000);
+      }
+    })();
 
     return () => {
-      if (syncPollRef.current) {
-        window.clearInterval(syncPollRef.current);
-        syncPollRef.current = null;
+      abort.abort();
+      if (syncStreamAbortRef.current === abort) {
+        syncStreamAbortRef.current = null;
       }
     };
   }, [syncStatus?.state, syncStatus?.serviceType, syncStatus?.serverId]);
@@ -2002,6 +2037,19 @@ function PlexTab() {
 			setCacheServerId(serverId);
     } catch (e) {
       setError(e instanceof ApiError ? e.message : "Failed to sync Plex library.");
+    }
+  };
+
+  const onDeleteServer = async (serverId: string) => {
+    setError(null);
+    try {
+      if (!confirm(`Delete Plex server '${serverId}'?`)) return;
+      await plexDeleteServer(serverId);
+      await load();
+      notifyConfiguredScopesUpdated();
+      setSyncStatus((prev) => (prev?.serverId === serverId ? null : prev));
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Failed to delete Plex server.");
     }
   };
 
@@ -2147,9 +2195,20 @@ function PlexTab() {
                     <td>{s.version ?? ""}</td>
                     <td>{s.lastLibrarySyncUtc ?? ""}</td>
                     <td style={{ textAlign: "right" }}>
-                      <button type="button" className="pill pill--neutral is-on" onClick={() => void onSyncLibrary(s.serverId)}>
-                        Sync library
-                      </button>
+						<div style={{ display: "flex", gap: "0.5rem", justifyContent: "flex-end", flexWrap: "wrap" }}>
+							<button type="button" className="pill pill--neutral is-on" onClick={() => void onSyncLibrary(s.serverId)}>
+								Sync library
+							</button>
+							<button
+								type="button"
+								className="app__navLink"
+								style={{ borderColor: "rgba(255, 107, 107, 0.4)" }}
+								onClick={() => void onDeleteServer(s.serverId)}
+								disabled={loading}
+							>
+								Delete
+							</button>
+						</div>
                     </td>
                   </tr>
                 ))}
@@ -2643,6 +2702,23 @@ function JellyfinTab() {
     }
   };
 
+  const onDelete = async () => {
+    if (!selectedServerId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      if (!confirm(`Delete Jellyfin server '${selectedServerId}'?`)) return;
+      await jellyfinDeleteServer(selectedServerId);
+      setSelectedServerId("");
+      await load();
+      notifyConfiguredScopesUpdated();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Failed to delete Jellyfin server.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const selected = servers.find((s) => s.serverId === selectedServerId) ?? null;
 
   return (
@@ -2674,6 +2750,15 @@ function JellyfinTab() {
           <button type="button" className="pill pill--neutral is-on" onClick={() => void onSync()} disabled={loading || !selectedServerId}>
             Sync library
           </button>
+      <button
+        type="button"
+        className="app__navLink"
+        style={{ borderColor: "rgba(255, 107, 107, 0.4)" }}
+        onClick={() => void onDelete()}
+        disabled={loading || !selectedServerId}
+      >
+        Delete
+      </button>
           <div style={{ marginLeft: "auto", color: "#8c93a6", fontWeight: 700 }}>
             Last sync: {selected?.lastLibrarySyncUtc ?? ""}
           </div>
@@ -2790,6 +2875,23 @@ function EmbyTab() {
     }
   };
 
+  const onDelete = async () => {
+    if (!selectedServerId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      if (!confirm(`Delete Emby server '${selectedServerId}'?`)) return;
+      await embyDeleteServer(selectedServerId);
+      setSelectedServerId("");
+      await load();
+      notifyConfiguredScopesUpdated();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Failed to delete Emby server.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const selected = servers.find((s) => s.serverId === selectedServerId) ?? null;
 
   return (
@@ -2821,6 +2923,15 @@ function EmbyTab() {
           <button type="button" className="pill pill--neutral is-on" onClick={() => void onSync()} disabled={loading || !selectedServerId}>
             Sync library
           </button>
+      <button
+        type="button"
+        className="app__navLink"
+        style={{ borderColor: "rgba(255, 107, 107, 0.4)" }}
+        onClick={() => void onDelete()}
+        disabled={loading || !selectedServerId}
+      >
+        Delete
+      </button>
           <div style={{ marginLeft: "auto", color: "#8c93a6", fontWeight: 700 }}>
             Last sync: {selected?.lastLibrarySyncUtc ?? ""}
           </div>

--- a/ui/src/pages/RoomPage.tsx
+++ b/ui/src/pages/RoomPage.tsx
@@ -4,9 +4,18 @@ import QRCode from "qrcode";
 import SwipeCardComponent from "../components/SwipeCard";
 import MovieDetailsModal from "../components/MovieDetailsModal";
 import { getServiceScope, SERVICE_SCOPE_UPDATED_EVENT, type ServiceScope } from "../serviceScope";
-import { castRoomQr, closeRoom, createRoom, fetchRoomSwipeDeck, fetchSwipeDeck, getRoom, getRoomJoinUrl, getRoomMatches, getRoomQrCastUrl, joinRoom, listCastDevices, sendRoomSwipe } from "../api/client";
+import { castRoomQr, closeRoom, createRoom, endCastingSession, fetchRoomSwipeDeck, fetchSwipeDeck, getRoom, getRoomJoinUrl, getRoomMatches, getRoomQrCastUrl, joinRoom, listCastDevices, sendRoomSwipe } from "../api/client";
 import type { CastDeviceDto, RoomJoinUrlResponse, RoomMatchesResponse, RoomStateResponse } from "../api/contracts";
-import { ensureGoogleCastSdkLoaded, getCurrentCastDevice, initGoogleCastContext, loadMediaToCastSession, requestCastSession, shouldUseGoogleCastSdk } from "../casting/googleCast";
+import {
+  ensureGoogleCastSdkLoaded,
+  getCurrentCastDevice,
+  initGoogleCastContext,
+  loadMediaToCastSession,
+  requestCastSession,
+  shouldUseGoogleCastSdk,
+  subscribeToCastMediaFinished,
+  subscribeToCastSessionEnded
+} from "../casting/googleCast";
 import { ApiError } from "../api/http";
 import { useAuth } from "../auth/AuthContext";
 import type { SwipeAction, SwipeCard } from "../types";
@@ -35,6 +44,42 @@ export default function RoomPage() {
   const [casting, setCasting] = useState(false);
   const [castMessage, setCastMessage] = useState<string | null>(null);
   const [castUiMode, setCastUiMode] = useState<"sdk" | "fallback">(() => (shouldUseGoogleCastSdk() ? "sdk" : "fallback"));
+
+  const qrCastSessionIdRef = useRef<string | null>(null);
+  const qrEndInFlightRef = useRef(false);
+
+  async function endActiveQrCastSessionBestEffort(): Promise<void> {
+    const sessionId = qrCastSessionIdRef.current;
+    if (!sessionId) return;
+    if (qrEndInFlightRef.current) return;
+
+    qrEndInFlightRef.current = true;
+    try {
+      await endCastingSession(sessionId);
+    } catch (e) {
+      // best-effort
+      void e;
+    } finally {
+      qrCastSessionIdRef.current = null;
+      qrEndInFlightRef.current = false;
+    }
+  }
+
+  useEffect(() => {
+    if (castUiMode !== "sdk") return;
+
+    const unsubEnded = subscribeToCastSessionEnded(() => {
+      void endActiveQrCastSessionBestEffort();
+    });
+    const unsubFinished = subscribeToCastMediaFinished(() => {
+      void endActiveQrCastSessionBestEffort();
+    });
+
+    return () => {
+      unsubEnded();
+      unsubFinished();
+    };
+  }, [castUiMode]);
 
   const [cards, setCards] = useState<SwipeCard[]>([]);
   const [deckLoading, setDeckLoading] = useState(false);
@@ -278,6 +323,9 @@ export default function RoomPage() {
     try {
       const updated = await closeRoom(roomId);
       setRoom(updated);
+
+			// Once the room is closed, the invite QR is no longer needed.
+			await endActiveQrCastSessionBestEffort();
     } catch (e) {
       if (e instanceof ApiError) {
         setError(e.message);
@@ -338,12 +386,19 @@ export default function RoomPage() {
         }
 
         const media = await getRoomQrCastUrl(roomId);
-        await loadMediaToCastSession({
-          url: media.url,
-          contentType: media.contentType,
-          title: media.title,
-          subTitle: media.subTitle,
-        });
+
+        qrCastSessionIdRef.current = media.sessionId ?? null;
+        try {
+          await loadMediaToCastSession({
+            url: media.url,
+            contentType: media.contentType,
+            title: media.title,
+            subTitle: media.subTitle,
+          });
+        } catch (e) {
+          await endActiveQrCastSessionBestEffort();
+          throw e;
+        }
 
         setCastMessage("Casting QR…");
         return;


### PR DESCRIPTION
Summary:
- Adds admin update checking support in the UI
- Adds casting diagnostics streaming (SSE) + cast session lifecycle tracking
- Adds server deletion endpoints (Plex/Jellyfin/Emby) and UI wiring
- Improves cast playback compatibility for Emby/Jellyfin (cast-optimized stream requests)

Notes:
- Casting diagnostics now streams via SSE instead of polling
- Cast sessions are ended best-effort on receiver disconnect/finish

## Summary by Sourcery

Add cast-aware playback and diagnostics streaming while improving admin control over media servers and swipe decks.

New Features:
- Add cast-optimized playback paths for Emby and Jellyfin, including direct cast URLs and Chromecast-oriented stream construction.
- Introduce server-sent events (SSE) endpoints and client wiring for casting diagnostics and Plex library sync status streaming in the admin UI.
- Expose endpoints and UI actions to delete Plex, Jellyfin, and Emby servers from the admin console, with scope list auto-refresh and fallback scope handling.
- Track casting sessions end-to-end, issuing session IDs for cast URLs, registering sessions for movies and room QR codes, and providing an API to end sessions.

Bug Fixes:
- Handle Emby and Jellyfin TMDB ID lookups more robustly by scanning provider IDs and paginated libraries instead of relying on brittle query operators.
- Avoid returning invalid swipe decks by increasing minimum deck sizes and excluding previously interacted titles.
- Ensure playback proxying avoids leaking sensitive query parameters in logs and supports HEAD requests for cast health checks.

Enhancements:
- Improve Emby and Jellyfin cast playback compatibility by enforcing mp4/AAC streams, stereo audio, and compatible subtitle handling, with loopback host rewriting for direct URLs to be reachable by cast devices.
- Optimize Emby/Jellyfin swipe deck generation by preferring cached TMDB metadata, persisting fetched details, and prioritizing richer cards while deduplicating results.
- Extend casting diagnostics to better capture session lifecycle events, including auto-ending prior sessions per device and ending sessions when playback completes or fails.
- Add Plex library sync job status publish/subscribe support with throttled updates to back the SSE status stream.
- Refine room and global swipe deck APIs to return more meaningful deck sizes and improve Jellyfin item resolution logging.
- Delay UI startup slightly in the dev script to reduce race conditions with the API startup.

Tests:
- Add unit tests for casting session lifecycle, including recasts on the same device, session cleanup on failures, and QR-room session registration.
- Add Emby playback provider tests to validate cast stream URL construction including device and media source identifiers.
- Update existing tests to cover new service settings repository delete support and other interface changes.