### PR TITLE
Bump version to 1.2.2

### DIFF
--- a/build/scripts/build-inno.ps1
+++ b/build/scripts/build-inno.ps1
@@ -4,7 +4,7 @@
 .DESCRIPTION
   Requires Inno Setup (iscc), .NET SDK, and Node/npm. Run from repo root.
   Builds the UI (npm run build in ui), publishes the API (so wwwroot is current), then runs iscc.
-  Run "npm install" in ui once if needed. Output: dist\Tindarr-1.0.2-setup.exe
+	Run "npm install" in ui once if needed. Output: dist\Tindarr-1.2.2-setup.exe
 .PARAMETER PublishDir
   Directory containing published API output. Default: dist\api (publish is run if missing).
 #>
@@ -52,5 +52,5 @@ if (-not $iscc) {
 
 if (-not $?) { throw "iscc failed." }
 
-$outExe = Join-Path $RepoRoot "dist\Tindarr-1.0.2-setup.exe"
+$outExe = Join-Path $RepoRoot "dist\Tindarr-1.2.2-setup.exe"
 Write-Host "Done: $outExe"

--- a/build/scripts/build-msi.ps1
+++ b/build/scripts/build-msi.ps1
@@ -3,11 +3,11 @@
   Builds the Tindarr MSI installer (WiX). Publishes the API, harvests files with Heat, then compiles and links.
 .DESCRIPTION
   Requires WiX Toolset (candle, heat, light) and .NET SDK. Run from repo root.
-  Output: dist\Tindarr-1.0.2.msi (or -OutPath).
+	Output: dist\Tindarr-1.2.2.msi (or -OutPath).
 .PARAMETER PublishDir
   Directory containing published API output. Default: dist\api (publish is run if missing).
 .PARAMETER OutPath
-  Path for the output MSI. Default: dist\Tindarr-1.0.2.msi.
+	Path for the output MSI. Default: dist\Tindarr-1.2.2.msi.
 #>
 Param(
 	[string]$PublishDir = "",
@@ -19,7 +19,7 @@ $ErrorActionPreference = "Stop"
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
 $WixDir = Join-Path $RepoRoot "installer\windows\wix"
 $DistApi = Join-Path $RepoRoot "dist\api"
-$DefaultMsi = Join-Path $RepoRoot "dist\Tindarr-1.0.2.msi"
+$DefaultMsi = Join-Path $RepoRoot "dist\Tindarr-1.2.2.msi"
 
 if (-not $PublishDir) { $PublishDir = $DistApi }
 if (-not $OutPath) { $OutPath = $DefaultMsi }

--- a/installer/windows/Tindarr.iss
+++ b/installer/windows/Tindarr.iss
@@ -8,15 +8,15 @@
 
 [Setup]
 AppName=Tindarr
-AppVersion=1.0.2
-AppVerName=Tindarr 1.0.2
+AppVersion=1.2.2
+AppVerName=Tindarr 1.2.2
 AppPublisher=SkibidiRizzi
 DefaultDirName={autopf}\Tindarr
 DefaultGroupName=Tindarr
 DisableProgramGroupPage=yes
 PrivilegesRequired=admin
 OutputDir=..\..\dist
-OutputBaseFilename=Tindarr-1.0.2-setup
+OutputBaseFilename=Tindarr-1.2.2-setup
 SetupIconFile=..\..\artifacts\tindarr.ico
 WizardImageFile=..\..\artifacts\tindarrsidebanner.png
 WizardSmallImageFile=..\..\artifacts\tindarrcropped.png

--- a/installer/windows/wix/Tindarr.wxs
+++ b/installer/windows/wix/Tindarr.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="Tindarr" Language="1033" Version="1.0.2" Manufacturer="Tindarr" UpgradeCode="B7E9E7E5-9A2C-4E8B-9F1D-3C5E7E9A2B4D">
+  <Product Id="*" Name="Tindarr" Language="1033" Version="1.2.2" Manufacturer="Tindarr" UpgradeCode="B7E9E7E5-9A2C-4E8B-9F1D-3C5E7E9A2B4D">
     <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" InstallPrivileges="elevated" Description="Tindarr Web API and UI" />
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of Tindarr is already installed." />

--- a/src/Tindarr.Application/Common/TindarrVersion.cs
+++ b/src/Tindarr.Application/Common/TindarrVersion.cs
@@ -3,5 +3,5 @@ namespace Tindarr.Application.Common;
 public static class TindarrVersion
 {
 	// Requested baseline for update checks.
-	public static readonly Version Current = new(1, 0, 0);
+	public static readonly Version Current = new(1, 2, 2);
 }

--- a/src/Tindarr.Application/Options/PlexOptions.cs
+++ b/src/Tindarr.Application/Options/PlexOptions.cs
@@ -14,7 +14,7 @@ public sealed class PlexOptions
 
 	public string Device { get; init; } = "Tindarr";
 
-	public string Version { get; init; } = "1.0.0";
+	public string Version { get; init; } = "1.2.2";
 
 	// Optional shared secret for Plex webhook ingestion.
 	// If set, callers must provide it via X-Tindarr-Webhook-Token header or ?token= query.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tindarr-ui",
-  "version": "0.1.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tindarr-ui",
-      "version": "0.1.0",
+      "version": "1.2.2",
       "dependencies": {
         "framer-motion": "^11.0.3",
         "qrcode.react": "^4.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tindarr-ui",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary by Sourcery

Update project version references to 1.2.2 across installers, application code, and UI metadata.

Enhancements:
- Align MSI and Inno Setup script output filenames and metadata with version 1.2.2.
- Update backend version constants used for update checks and Plex client identification to 1.2.2.
- Bump UI package version to 1.2.2 for consistency with the overall release version.